### PR TITLE
feat: Add manual standup trigger commands for admins and owners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2025-01-09
+
 ### Added
 
 - Manual standup trigger commands for admins and organization owners
@@ -157,7 +159,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    - Push to remote
    - Trigger automated deployment
 
-[Unreleased]: https://github.com/jnahian/daily-dose/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/jnahian/daily-dose/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/jnahian/daily-dose/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/jnahian/daily-dose/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/jnahian/daily-dose/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/jnahian/daily-dose/compare/v1.0.0...v1.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Manual standup trigger commands for admins and organization owners
+  - `/dd-standup-remind [team-name]` - Send standup reminders to team members
+  - `/dd-standup-post [YYYY-MM-DD] [team-name]` - Post standup summary for specific date
+  - `/dd-standup-preview [YYYY-MM-DD] [team-name]` - Preview standup summary (ephemeral)
+  - `/dd-standup-followup [team-name]` - Send followup reminders to non-responders
+- Permission system with role-based access control
+  - `permissionHelper.js` utility for checking Organization Owner and Team Admin roles
+  - `isOrganizationOwner()`, `isTeamAdmin()`, and `canManageTeam()` functions
+- Context-aware team resolution in `teamHelper.js`
+  - Admins can run commands from team channel without specifying team name
+  - Owners must specify team name when running from any location
+  - `resolveTeamFromContext()` function for automatic team detection
+  - `parseCommandArguments()` for flexible date and team name parsing
+- Block helper functions for formatted command responses
+  - `createCommandSuccessBlocks()` - Success messages with details
+  - `createCommandErrorBlocks()` - Error messages with suggestions
+  - `createPermissionDeniedBlocks()` - Permission error messages
+  - `createStandupPreviewHeaderBlocks()` - Preview header formatting
+  - `createNoDataBlocks()` - No data available messages
+- Comprehensive audit logging for all admin actions
+- User stories and implementation plan documentation
+
 ## [1.2.0] - 2025-01-09
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ Daily Dose is a Slack bot that automates daily standup meetings for teams. Built
 - **Entry Point**: `src/app.js` - Main application file with Slack Bolt setup
 - **Commands**: `src/commands/` - Slack slash command handlers (team, leave, standup)
 - **Services**: `src/services/` - Business logic (scheduler, standup, team, user)
-- **Utilities**: `src/utils/` - Helper functions (date, message, command, user, logger)
+- **Utilities**: `src/utils/` - Helper functions (date, message, command, user, logger, permission, team)
 - **Database**: Prisma ORM with PostgreSQL via Supabase
 
 ### Key Services
@@ -86,6 +86,27 @@ Uses node-cron for:
 4. Responses collected via interactive modals
 5. Summary posted to team channel at posting time
 6. Late submissions added as thread replies
+
+### Permission System
+The application implements a role-based permission system for administrative commands:
+- **Organization Owners**: Users who created the organization (have access to all teams)
+- **Team Admins**: Members with ADMIN role in TeamMember table (can manage specific teams)
+- **Permission Helper** (`src/utils/permissionHelper.js`): Provides functions to check user roles
+- **Context-Aware Commands**: Automatically resolve team from channel for admins, require explicit team name for owners
+
+### Manual Standup Trigger Commands (Admin/Owner)
+Four new slash commands allow manual control of automated standup operations:
+- `/dd-standup-remind [team-name]` - Manually send standup reminders to all active team members
+- `/dd-standup-post [date] [team-name]` - Post standup summary for any date (includes late responses)
+- `/dd-standup-preview [date] [team-name]` - Preview standup summary as ephemeral message before posting
+- `/dd-standup-followup [team-name]` - Send followup reminders to members who haven't responded
+
+**Implementation Details:**
+- Commands use context-aware team resolution via `teamHelper.js`
+- Admins can run commands in team channel without team name
+- Owners must specify team name when running from any location
+- Date parsing supports optional YYYY-MM-DD format for historical standups
+- All commands integrated with existing `schedulerService` and `standupService` logic
 
 ### Testing Approach
 No automated tests currently configured - manual testing via Slack interactions and script execution.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,185 @@ The bot will send you a DM reminder at your team's configured time. Click the "S
   - **Parameters**: At least one parameter required (mention=on/off controls visibility in "not responded" list, notify=on/off controls reminder notifications)
 - The bot also sends automatic DM reminders with interactive buttons
 
+### 🔧 Manual Standup Trigger Commands ⚠️ (Admin/Owner Only)
+
+These commands allow team admins and organization owners to manually trigger standup operations that are normally automated by the scheduler.
+
+**Permission Requirements:**
+- **Team Admins**: Can use commands in their team's channel without specifying team name
+- **Organization Owners**: Can use commands from any channel but must specify team name
+
+#### Command Overview
+
+- `/dd-standup-remind [team-name]` - Send standup reminders to team members ⚠️ **(admin/owner only)**
+- `/dd-standup-post [YYYY-MM-DD] [team-name]` - Post standup summary to channel ⚠️ **(admin/owner only)**
+- `/dd-standup-preview [YYYY-MM-DD] [team-name]` - Preview standup summary before posting ⚠️ **(admin/owner only)**
+- `/dd-standup-followup [team-name]` - Send followup reminders to non-responders ⚠️ **(admin/owner only)**
+
+#### Context-Aware Behavior
+
+**For Team Admins (in team channel):**
+```bash
+# Send reminders to all team members (uses current channel's team)
+/dd-standup-remind
+
+# Post today's standup summary (uses current channel's team)
+/dd-standup-post
+
+# Post standup summary for specific date (uses current channel's team)
+/dd-standup-post 2024-12-20
+
+# Preview today's standup (uses current channel's team)
+/dd-standup-preview
+
+# Preview standup for specific date (uses current channel's team)
+/dd-standup-preview 2024-12-20
+
+# Send followup reminders to members who haven't responded (uses current channel's team)
+/dd-standup-followup
+```
+
+**For Organization Owners (from any channel):**
+```bash
+# Send reminders to Engineering team members
+/dd-standup-remind Engineering
+
+# Post today's standup summary for Marketing team
+/dd-standup-post Marketing
+
+# Post standup summary for specific date for DevOps team
+/dd-standup-post 2024-12-20 DevOps
+
+# Preview today's standup for QA team
+/dd-standup-preview QA
+
+# Preview standup for specific date for Engineering team
+/dd-standup-preview 2024-12-20 Engineering
+
+# Send followup reminders to Engineering team non-responders
+/dd-standup-followup Engineering
+```
+
+#### Detailed Command Documentation
+
+**Standup Remind** - `/dd-standup-remind [team-name]`
+- **Purpose**: Manually send standup reminders to all eligible team members
+- **Who receives reminders**: Active team members who are not on leave, not on holidays, and have notifications enabled
+- **Context-aware**:
+  - Admins in team channel: `/dd-standup-remind`
+  - Owners from anywhere: `/dd-standup-remind Engineering`
+- **Use cases**:
+  - Send early reminders before the scheduled time
+  - Send additional reminders if team members forgot
+  - Test reminder functionality for new teams
+
+**Standup Post** - `/dd-standup-post [YYYY-MM-DD] [team-name]`
+- **Purpose**: Manually post standup summary to the team channel
+- **Date format**: YYYY-MM-DD (e.g., 2024-12-20)
+- **Default**: Posts today's standup if no date specified
+- **Context-aware**:
+  - Admins in team channel: `/dd-standup-post` or `/dd-standup-post 2024-12-20`
+  - Owners from anywhere: `/dd-standup-post Engineering` or `/dd-standup-post 2024-12-20 Engineering`
+- **Use cases**:
+  - Post summary early before scheduled posting time
+  - Re-post summary if original was deleted
+  - Post past standup summaries that were missed
+
+**Standup Preview** - `/dd-standup-preview [YYYY-MM-DD] [team-name]`
+- **Purpose**: Preview standup summary before posting to channel (ephemeral message)
+- **Date format**: YYYY-MM-DD (e.g., 2024-12-20)
+- **Default**: Previews today's standup if no date specified
+- **Visibility**: Only visible to you (ephemeral)
+- **Context-aware**:
+  - Admins in team channel: `/dd-standup-preview` or `/dd-standup-preview 2024-12-20`
+  - Owners from anywhere: `/dd-standup-preview Engineering` or `/dd-standup-preview 2024-12-20 Engineering`
+- **Use cases**:
+  - Check what the summary looks like before posting
+  - Verify all expected submissions are included
+  - Review standup data without posting to channel
+
+**Standup Followup** - `/dd-standup-followup [team-name]`
+- **Purpose**: Send followup reminders to team members who haven't submitted today's standup
+- **Who receives**: Active team members who haven't submitted and have notifications enabled
+- **Context-aware**:
+  - Admins in team channel: `/dd-standup-followup`
+  - Owners from anywhere: `/dd-standup-followup Engineering`
+- **Use cases**:
+  - Gentle reminder for team members who missed the initial reminder
+  - Follow up before posting time if participation is low
+  - Encourage last-minute submissions
+
+#### Permission Errors
+
+```bash
+# Error: Not an admin or owner
+/dd-standup-remind
+# Response: "❌ You must be a team admin or organization owner to trigger standup reminders"
+
+# Error: Admin trying to use command outside team channel without team name
+/dd-standup-remind
+# Response: "❌ No team found in this channel. As an admin, please run this command from your team's channel, or provide the team name if you're an owner"
+
+# Error: Team doesn't exist
+/dd-standup-remind NonexistentTeam
+# Response: "❌ Team 'NonexistentTeam' not found"
+
+# Error: Invalid date format
+/dd-standup-post 12-20-2024 Engineering
+# Response: "❌ Invalid date format. Use YYYY-MM-DD (e.g., 2024-12-20)"
+```
+
+#### Example Workflows
+
+**Scenario 1: Admin sending early reminder**
+```bash
+# Admin in #engineering channel wants to send reminder at 9:00 instead of scheduled 9:30
+/dd-standup-remind
+# Response: "✅ Standup reminders sent to 5 team members for Engineering team"
+```
+
+**Scenario 2: Owner posting multiple team summaries**
+```bash
+# Owner from #general channel posts summaries for multiple teams
+/dd-standup-post Engineering
+/dd-standup-post Marketing
+/dd-standup-post DevOps
+# Each team's summary posted to their respective channels
+```
+
+**Scenario 3: Preview before posting**
+```bash
+# Admin wants to check standup participation before posting
+/dd-standup-preview
+# Reviews the preview (only visible to admin)
+# If satisfied, posts the summary
+/dd-standup-post
+# Response: "✅ Standup summary posted to #engineering"
+```
+
+**Scenario 4: Following up on low participation**
+```bash
+# Admin checks preview at 9:45 (posting time is 10:00)
+/dd-standup-preview
+# Sees only 2 out of 8 members responded
+# Sends followup reminder
+/dd-standup-followup
+# Response: "✅ Followup reminders sent to 6 team members who haven't submitted"
+# Waits a few minutes and checks again
+/dd-standup-preview
+# Now 6 out of 8 members responded, posts summary
+/dd-standup-post
+```
+
+**Scenario 5: Posting historical standup**
+```bash
+# Owner realizes yesterday's standup wasn't posted
+/dd-standup-preview 2024-12-19 Engineering
+# Reviews yesterday's submissions
+/dd-standup-post 2024-12-19 Engineering
+# Response: "✅ Standup summary posted to #engineering for 2024-12-19"
+```
+
 ### 👥 Team Management
 
 - `/dd-team-list` - List all teams in your organization with detailed timing information

--- a/docs/daily-dose-complete-guide.md
+++ b/docs/daily-dose-complete-guide.md
@@ -94,7 +94,9 @@ daily-dose/
 │   │   ├── commandHelper.js   # Command processing helpers
 │   │   ├── messageHelper.js   # Message formatting helpers
 │   │   ├── blockHelper.js     # Slack block UI helpers
-│   │   └── userHelper.js      # User data helpers
+│   │   ├── userHelper.js      # User data helpers
+│   │   ├── permissionHelper.js # Permission checking (Owner/Admin)
+│   │   └── teamHelper.js      # Team resolution and parsing
 │   └── scripts/
 │       ├── seedOrg.js         # Manual organization setup
 │       ├── updateSlackManifest.js # Slack manifest management
@@ -428,6 +430,12 @@ Add these Bot Token Scopes:
 **Standup Commands:**
 - `/dd-standup` - Submit standup manually
 - `/dd-standup-update` - Update standup for any day
+
+**Manual Standup Trigger Commands ⚠️ (Admin/Owner Only):**
+- `/dd-standup-remind [team-name]` - Send standup reminders to team members ⚠️ **(admin/owner only)**
+- `/dd-standup-post [YYYY-MM-DD] [team-name]` - Post standup summary to channel ⚠️ **(admin/owner only)**
+- `/dd-standup-preview [YYYY-MM-DD] [team-name]` - Preview standup summary before posting ⚠️ **(admin/owner only)**
+- `/dd-standup-followup [team-name]` - Send followup reminders to non-responders ⚠️ **(admin/owner only)**
 
 **Team Management Commands:**
 - `/dd-team-create` - Create a new team ⚠️ **(admin only)**
@@ -1557,6 +1565,12 @@ function setupCommands(app) {
   // Standup commands (primary functionality) - wrapped with formatting removal middleware
   app.command("/dd-standup", stripFormatting(), standupCommands.submitManual);
   app.command("/dd-standup-update", stripFormatting(), standupCommands.updateStandup);
+
+  // Admin/Owner standup management commands - wrapped with formatting removal middleware ⚠️ admin/owner only
+  app.command("/dd-standup-remind", stripFormatting(), standupCommands.sendReminders);
+  app.command("/dd-standup-post", stripFormatting(), standupCommands.postStandup);
+  app.command("/dd-standup-preview", stripFormatting(), standupCommands.previewStandup);
+  app.command("/dd-standup-followup", stripFormatting(), standupCommands.sendFollowupReminders);
 
   // Team management commands - wrapped with formatting removal middleware
   app.command("/dd-team-list", stripFormatting(), teamCommands.listTeams);

--- a/docs/implementation-plans/manual-standup-triggers-implementation.md
+++ b/docs/implementation-plans/manual-standup-triggers-implementation.md
@@ -1,0 +1,332 @@
+# Implementation Plan: Manual Standup Trigger Slash Commands
+
+## Overview
+Implement slash commands for admins and owners to manually trigger standup operations (reminders, posts, previews, followups).
+
+**Approach**: Option A - Context-aware single command
+- Admins in team channel: `/dd-standup-remind` (auto-detects team from channel)
+- Owners anywhere: `/dd-standup-remind Engineering Team` (must specify team name)
+
+## Step-by-Step Implementation
+
+### Phase 1: Core Infrastructure Setup
+
+#### 1. Create Permission Helper Utility
+- [ ] Create `src/utils/permissionHelper.js`
+- [ ] Implement `isOrganizationOwner(userId, organizationId)` function
+  - Query User table to check if user created the organization
+  - Return boolean
+- [ ] Implement `isTeamAdmin(userId, teamId)` function
+  - Query TeamMember table to check if user has ADMIN role
+  - Return boolean
+- [ ] Implement `canManageTeam(userId, teamId)` function
+  - Check if user is owner OR admin of the team
+  - Return boolean with role information
+- [ ] Add comprehensive JSDoc documentation
+
+#### 2. Create Team Resolution Helper
+- [ ] Add function `resolveTeamFromContext(channelId, teamName, userId)` to `src/utils/teamHelper.js` (or create if doesn't exist)
+  - If teamName provided, find team by name (case-insensitive)
+  - If no teamName, find team by channelId
+  - Validate team exists and is active
+  - Return team object or null
+- [ ] Add function `getTeamsByOrganization(organizationId)` for owner operations
+- [ ] Add error message helpers for team not found scenarios
+
+#### 3. Create Command Response Helpers
+- [ ] Add functions to `src/utils/blockHelper.js`:
+  - `createCommandSuccessBlocks(message, details)` - Success response with optional details
+  - `createCommandErrorBlocks(message, suggestions)` - Error response with suggestions
+  - `createPermissionDeniedBlocks(requiredRole)` - Permission error message
+  - `createStandupPreviewBlocks(standupData)` - Preview format for ephemeral messages
+- [ ] Follow guidelines from `docs/slack-markdown-guidelines.md`
+
+### Phase 2: Standup Reminder Command
+
+#### 4. Create `/dd-standup-remind` Command Handler
+- [ ] Create `src/commands/standup/remindCommand.js`
+- [ ] Import required services and utilities
+- [ ] Implement main command handler function:
+  - [ ] Parse command text to extract optional team name
+  - [ ] Get user from database using `command.user_id`
+  - [ ] Resolve team using `resolveTeamFromContext(command.channel_id, teamName, user.id)`
+  - [ ] Check permissions using `canManageTeam(user.id, team.id)`
+  - [ ] If not authorized, send permission denied message
+- [ ] Call reminder logic:
+  - [ ] Import `schedulerService.sendStandupReminders(team)`
+  - [ ] Initialize schedulerService with app instance
+  - [ ] Execute reminder sending
+  - [ ] Capture count of reminders sent
+- [ ] Send response:
+  - [ ] Success: Show count of reminders sent
+  - [ ] Error: Show error message with troubleshooting steps
+- [ ] Add error handling for all scenarios
+
+#### 5. Register Reminder Command
+- [ ] Add command registration in `src/app.js` or command index
+- [ ] Map `/dd-standup-remind` to handler
+- [ ] Test command in Slack (manual testing)
+
+### Phase 3: Standup Post Command
+
+#### 6. Create `/dd-standup-post` Command Handler
+- [ ] Create `src/commands/standup/postCommand.js`
+- [ ] Implement main command handler function:
+  - [ ] Parse command text to extract optional date and team name
+  - [ ] Validate date format if provided (YYYY-MM-DD)
+  - [ ] Get user from database
+  - [ ] Resolve team using context
+  - [ ] Check permissions using `canManageTeam(user.id, team.id)`
+- [ ] Call posting logic:
+  - [ ] Determine target date (provided or today in team timezone)
+  - [ ] Import `standupService.postTeamStandup(team, date, app)`
+  - [ ] Execute standup posting
+  - [ ] Capture message timestamp
+- [ ] Handle no data scenario:
+  - [ ] Check if responses exist before posting
+  - [ ] Show informative message if no data
+- [ ] Send response:
+  - [ ] Success: Show confirmation with message timestamp
+  - [ ] Error: Show error with context
+- [ ] Add comprehensive error handling
+
+#### 7. Register Post Command
+- [ ] Add command registration in `src/app.js`
+- [ ] Map `/dd-standup-post` to handler
+- [ ] Test command in Slack
+
+### Phase 4: Standup Preview Command
+
+#### 8. Create `/dd-standup-preview` Command Handler
+- [ ] Create `src/commands/standup/previewCommand.js`
+- [ ] Implement main command handler function:
+  - [ ] Parse command text for optional date and team name
+  - [ ] Validate date format if provided
+  - [ ] Get user from database
+  - [ ] Resolve team using context
+  - [ ] Check permissions using `canManageTeam(user.id, team.id)`
+- [ ] Generate preview:
+  - [ ] Determine target date
+  - [ ] Get responses using `standupService.getTeamResponses(teamId, date)`
+  - [ ] Get late responses using `standupService.getLateResponses(teamId, date)`
+  - [ ] Get active members using `standupService.getActiveMembers(teamId, date)`
+  - [ ] Get members on leave from database
+  - [ ] Calculate not submitted list
+  - [ ] Format using `standupService.formatStandupMessage()`
+- [ ] Send ephemeral response:
+  - [ ] Use `respond()` with `response_type: "ephemeral"`
+  - [ ] Include preview header
+  - [ ] Show formatted standup data
+  - [ ] Add note about using `/dd-standup-post` to publish
+- [ ] Handle no data scenario
+
+#### 9. Register Preview Command
+- [ ] Add command registration in `src/app.js`
+- [ ] Map `/dd-standup-preview` to handler
+- [ ] Test command in Slack
+
+### Phase 5: Standup Followup Command
+
+#### 10. Create `/dd-standup-followup` Command Handler
+- [ ] Create `src/commands/standup/followupCommand.js`
+- [ ] Implement main command handler function:
+  - [ ] Parse command text for optional team name
+  - [ ] Get user from database
+  - [ ] Resolve team using context
+  - [ ] Check permissions using `canManageTeam(user.id, team.id)`
+- [ ] Call followup logic:
+  - [ ] Import `schedulerService.sendFollowupReminders(team)`
+  - [ ] Initialize schedulerService with app instance
+  - [ ] Execute followup reminder sending
+  - [ ] Capture count of reminders sent
+- [ ] Send response:
+  - [ ] Success: Show count of followup reminders sent
+  - [ ] Error: Show error message
+- [ ] Add error handling
+
+#### 11. Register Followup Command
+- [ ] Add command registration in `src/app.js`
+- [ ] Map `/dd-standup-followup` to handler
+- [ ] Test command in Slack
+
+### Phase 6: Slack Manifest Updates
+
+#### 12. Update Slack App Manifest
+- [ ] Open `slack-manifest.json` or equivalent
+- [ ] Add new slash commands to manifest:
+  ```json
+  {
+    "command": "/dd-standup-remind",
+    "url": "https://your-app-url.com/slack/commands",
+    "description": "Send standup reminders to team members",
+    "usage_hint": "[team-name] (team name required for owners)"
+  }
+  ```
+- [ ] Add `/dd-standup-post` with description and usage hint
+- [ ] Add `/dd-standup-preview` with description and usage hint
+- [ ] Add `/dd-standup-followup` with description and usage hint
+- [ ] Update bot scopes if needed (should already have required scopes)
+
+#### 13. Deploy Manifest Changes
+- [ ] Run `npm run manifest:dry-run` to preview changes
+- [ ] Review changes carefully
+- [ ] Run `npm run manifest:update` to deploy
+- [ ] Verify commands appear in Slack workspace
+
+### Phase 7: Documentation
+
+#### 14. Update README.md
+- [ ] Add new commands section under "Slash Commands"
+- [ ] Document each command with:
+  - Command syntax
+  - Description
+  - Required permissions
+  - Examples for admins and owners
+  - Error scenarios
+- [ ] Add troubleshooting section for common issues
+
+#### 15. Update CLAUDE.md
+- [ ] Add commands to "Development Commands" section
+- [ ] Document manual trigger workflow
+- [ ] Add notes about permission system
+- [ ] Update architecture notes if needed
+
+#### 16. Create Usage Documentation
+- [ ] Create `docs/commands/manual-standup-triggers.md`
+- [ ] Provide detailed examples for each command
+- [ ] Include screenshots or example outputs
+- [ ] Document permission matrix
+- [ ] Add FAQ section
+
+### Phase 8: Testing & Validation
+
+#### 17. Unit Testing Preparation
+- [ ] Identify testable functions in helpers
+- [ ] Create test data fixtures for teams, users, responses
+- [ ] Set up test database or mocks
+
+#### 18. Manual Testing - Admin Scenarios
+- [ ] Test `/dd-standup-remind` in team channel as admin
+- [ ] Test `/dd-standup-post` in team channel as admin
+- [ ] Test `/dd-standup-post 2025-01-15` with past date
+- [ ] Test `/dd-standup-preview` in team channel
+- [ ] Test `/dd-standup-followup` in team channel
+- [ ] Verify permission denied for non-admin users
+- [ ] Test with team that has no responses
+- [ ] Test with team that has members on leave
+
+#### 19. Manual Testing - Owner Scenarios
+- [ ] Test `/dd-standup-remind Engineering Team` as owner
+- [ ] Test `/dd-standup-post Marketing Team` as owner
+- [ ] Test `/dd-standup-post Product Team 2025-01-15` as owner
+- [ ] Test `/dd-standup-preview Sales Team` as owner
+- [ ] Test `/dd-standup-followup Support Team` as owner
+- [ ] Test with non-existent team name
+- [ ] Test with team names containing spaces
+
+#### 20. Error Scenario Testing
+- [ ] Test with invalid date format
+- [ ] Test with channel not associated with any team
+- [ ] Test with user not in database (shouldn't happen but handle gracefully)
+- [ ] Test with team that has no active members
+- [ ] Test with database connection errors
+- [ ] Test with Slack API errors
+
+#### 21. Edge Case Testing
+- [ ] Test command during actual automated standup time
+- [ ] Test posting multiple times for same date
+- [ ] Test with team in different timezone
+- [ ] Test with very long team names
+- [ ] Test with special characters in team names
+- [ ] Test rapid consecutive command execution
+
+### Phase 9: Monitoring & Rollout
+
+#### 22. Add Logging
+- [ ] Add structured logging for all command executions
+- [ ] Log permission checks and results
+- [ ] Log team resolution attempts
+- [ ] Log API calls to Slack
+- [ ] Add success/failure metrics
+
+#### 23. Error Monitoring Setup
+- [ ] Ensure Sentry or error tracking captures command errors
+- [ ] Add custom error tags for manual triggers
+- [ ] Set up alerts for permission errors
+- [ ] Monitor API rate limits
+
+#### 24. Rollout Plan
+- [ ] Deploy to staging/test workspace first
+- [ ] Test with small group of beta users
+- [ ] Gather feedback on UX and error messages
+- [ ] Make adjustments based on feedback
+- [ ] Deploy to production
+- [ ] Announce new commands to users
+- [ ] Monitor usage and errors for first week
+
+### Phase 10: Cleanup & Optimization
+
+#### 25. Code Review & Refactoring
+- [ ] Review all new code for consistency
+- [ ] Ensure error messages are user-friendly
+- [ ] Check for code duplication
+- [ ] Optimize database queries
+- [ ] Add missing JSDoc comments
+
+#### 26. Performance Optimization
+- [ ] Profile command response times
+- [ ] Add caching for permission checks if needed
+- [ ] Optimize team resolution queries
+- [ ] Add rate limiting if necessary
+
+#### 27. Future Enhancements Preparation
+- [ ] Document potential improvements
+- [ ] Create issues for future features:
+  - Bulk operations for owners
+  - Scheduled manual posts
+  - Analytics dashboard
+  - Webhook notifications
+- [ ] Gather user feedback for prioritization
+
+## Success Criteria
+
+- ✅ All four commands are functional and registered in Slack
+- ✅ Permission system correctly differentiates admins and owners
+- ✅ Context-aware team resolution works reliably
+- ✅ Error messages are clear and actionable
+- ✅ Documentation is complete and accurate
+- ✅ Manual testing covers all scenarios
+- ✅ No regressions in existing standup functionality
+- ✅ Commands work across multiple teams and timezones
+
+## Estimated Effort
+
+- **Phase 1-2**: 4-6 hours (infrastructure and first command)
+- **Phase 3-5**: 6-8 hours (remaining commands)
+- **Phase 6-7**: 2-3 hours (manifest and docs)
+- **Phase 8**: 4-6 hours (comprehensive testing)
+- **Phase 9-10**: 2-4 hours (monitoring and cleanup)
+
+**Total**: 18-27 hours
+
+## Dependencies
+
+- Existing services: `schedulerService`, `standupService`, `teamService`
+- Database: Prisma schema (User, Team, TeamMember, StandupResponse)
+- Slack API: Bolt framework, slash command endpoints
+- Scripts: Logic from `sendManualStandup.js` and `triggerStandup.js`
+
+## Risk Mitigation
+
+- **Permission bypass**: Thorough testing of permission checks
+- **Data inconsistency**: Validate all inputs before processing
+- **API rate limits**: Implement rate limiting and backoff
+- **User confusion**: Clear error messages and comprehensive docs
+- **Channel access**: Reuse troubleshooting logic from existing scripts
+
+---
+
+**Status**: Ready for Implementation
+**Created**: 2025-01-09
+**Approach**: Option A - Context-aware single command
+**Author**: Generated with Claude Code

--- a/docs/user-stories/manual-standup-triggers.md
+++ b/docs/user-stories/manual-standup-triggers.md
@@ -1,0 +1,207 @@
+# User Story: Manual Standup Trigger Slash Commands
+
+## Overview
+Enable team admins and organization owners to manually trigger standup operations (reminders and posts) through Slack slash commands, providing flexibility in standup management beyond automated scheduling.
+
+## User Roles
+- **Team Admin**: Member with ADMIN role in a specific team
+- **Organization Owner**: User who created the organization (has owner privileges across all teams)
+
+## Current State
+Manual standup operations are currently available through Node.js scripts:
+- `scripts/sendManualStandup.js` - Post standup summaries, send reminders, troubleshoot
+- `scripts/triggerStandup.js` - Trigger standup and followup reminders
+
+## User Stories
+
+### Story 1: Admin Triggers Standup Reminder for Own Team
+**As a** team admin
+**I want to** manually trigger standup reminders for my team
+**So that** I can prompt team members to submit their standups when needed (e.g., after technical issues, schedule changes)
+
+**Acceptance Criteria:**
+- Admin can use `/dd-standup-remind` command in their team's channel
+- System sends DM reminders to all active team members who haven't submitted standup for today
+- System respects leave status and work days configuration
+- Admin receives confirmation message with number of reminders sent
+- Command only works if user is an admin of the team associated with the channel
+
+**Example Usage:**
+```
+/dd-standup-remind
+```
+**Response:**
+```
+✅ Sent standup reminders to 5 team members
+```
+
+### Story 2: Admin Triggers Standup Post for Own Team
+**As a** team admin
+**I want to** manually post the standup summary for my team
+**So that** I can share standup updates at any time (e.g., before scheduled time, after collecting late submissions)
+
+**Acceptance Criteria:**
+- Admin can use `/dd-standup-post` command in their team's channel
+- System collects all standup responses submitted for today
+- System posts formatted standup summary to the channel
+- Late submissions are posted as thread replies
+- If no responses exist, system notifies admin
+- Command only works if user is an admin of the team associated with the channel
+
+**Example Usage:**
+```
+/dd-standup-post
+```
+**Response:**
+```
+✅ Standup posted successfully
+📝 Message timestamp: 1234567890.123456
+```
+
+### Story 3: Admin Posts Standup for Specific Date
+**As a** team admin
+**I want to** post standup summary for a specific past date
+**So that** I can share missed or delayed standup reports
+
+**Acceptance Criteria:**
+- Admin can use `/dd-standup-post [YYYY-MM-DD]` with optional date parameter
+- System retrieves responses for the specified date
+- System posts formatted summary with date in header
+- If no responses exist for that date, system notifies admin
+- Date validation ensures format is correct
+
+**Example Usage:**
+```
+/dd-standup-post 2025-01-15
+```
+**Response:**
+```
+✅ Standup posted successfully for 2025-01-15
+📝 Message timestamp: 1234567890.123456
+```
+
+### Story 4: Admin Previews Standup Before Posting
+**As a** team admin
+**I want to** preview the standup summary before posting it publicly
+**So that** I can verify the content and decide whether to post
+
+**Acceptance Criteria:**
+- Admin can use `/dd-standup-preview` command in their team's channel
+- System shows formatted standup summary as ephemeral message (only visible to admin)
+- Preview includes all sections: responses, late submissions, not responded, on leave
+- Admin can then use `/dd-standup-post` to actually post if satisfied
+- Preview includes timestamp and date information
+
+**Example Usage:**
+```
+/dd-standup-preview
+```
+**Response (ephemeral):**
+```
+🔍 Standup Preview for Today
+
+📊 Daily Standup — Engineering Team
+📅 Jan 15, 2025
+👥 8/10 members responded
+
+[... full standup preview ...]
+```
+
+### Story 5: Owner Triggers Operations for Any Team
+**As an** organization owner
+**I want to** manually trigger standup operations for any team in my organization
+**So that** I can help teams with standup management across the organization
+
+**Acceptance Criteria:**
+- Owner can use `/dd-standup-remind [team-name]` to send reminders to any team
+- Owner can use `/dd-standup-post [team-name]` to post standup for any team
+- Owner can use `/dd-standup-preview [team-name]` to preview standup for any team
+- System validates team name and shows error if team not found
+- If team name contains spaces, it should be quoted or handled properly
+- Owner receives confirmation messages similar to admin commands
+
+**Example Usage:**
+```
+/dd-standup-remind Engineering Team
+/dd-standup-post Marketing Team 2025-01-15
+/dd-standup-preview Product Team
+```
+
+### Story 6: Admin Triggers Followup Reminders
+**As a** team admin
+**I want to** send followup reminders to members who haven't submitted standup
+**So that** I can ensure maximum participation as the deadline approaches
+
+**Acceptance Criteria:**
+- Admin can use `/dd-standup-followup` command in their team's channel
+- System identifies members who haven't submitted standup for today
+- System sends DM reminders only to non-responding members
+- System respects leave status and work days
+- Admin receives confirmation with count of followup reminders sent
+
+**Example Usage:**
+```
+/dd-standup-followup
+```
+**Response:**
+```
+✅ Sent followup reminders to 3 team members
+```
+
+## Permission Matrix
+
+| Command | Admin (Own Team) | Owner (Any Team) | Regular Member |
+|---------|------------------|------------------|----------------|
+| `/dd-standup-remind` | ✅ | ✅ (with team name) | ❌ |
+| `/dd-standup-post` | ✅ | ✅ (with team name) | ❌ |
+| `/dd-standup-preview` | ✅ | ✅ (with team name) | ❌ |
+| `/dd-standup-followup` | ✅ | ✅ (with team name) | ❌ |
+
+## Technical Considerations
+
+### Command Structure
+```
+/dd-standup-remind [team-name]       # Team name required for owners, optional for admins in team channel
+/dd-standup-post [date] [team-name]  # Date optional (YYYY-MM-DD), team name for owners
+/dd-standup-preview [date] [team-name]
+/dd-standup-followup [team-name]
+```
+
+### Permission Checks
+1. Verify user is authenticated (exists in User table)
+2. Check if user is organization owner (User.organizationId matches team's organizationId)
+3. If not owner, check if user is admin of the team (TeamMember.role === 'ADMIN')
+4. For channel-based commands, verify team is associated with the channel
+
+### Error Scenarios
+- User lacks permissions → Show error message
+- Team not found → Show error with team name
+- Channel not associated with team → Guide user to provide team name
+- No responses for date → Inform user no data available
+- API failures → Show troubleshooting guidance
+
+### Integration with Existing Scripts
+Reuse logic from:
+- `scripts/sendManualStandup.js` → Post and preview functionality
+- `scripts/triggerStandup.js` → Reminder functionality
+- `src/services/schedulerService.js` → Reminder and followup logic
+- `src/services/standupService.js` → Formatting and posting logic
+
+## Success Metrics
+- Admins can trigger operations without technical knowledge
+- Reduced dependency on manual script execution
+- Improved standup participation through timely reminders
+- Better visibility of standup data through preview feature
+
+## Future Enhancements
+- Bulk operations for owners (remind all teams, post all teams)
+- Scheduled manual posts (post at specific time)
+- Analytics on manual trigger usage
+- Webhook notifications for manual triggers
+- Integration with troubleshooting command for channel access issues
+
+---
+
+**Status**: Draft
+**Created**: 2025-01-09
+**Author**: Generated with Claude Code

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "daily-dose",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "daily-dose",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^6.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daily-dose",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "index.js",
   "directories": {
     "doc": "docs"

--- a/public/changelog.html
+++ b/public/changelog.html
@@ -255,20 +255,20 @@
     <!-- Changelog Versions -->
     <section class="py-16">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <!-- Unreleased -->
+        <!-- Version 1.3.0 -->
         <div
-          class="version-card bg-white rounded-xl shadow-lg p-8 mb-8 glow-effect border-2 border-amber-500"
+          class="version-card bg-white rounded-xl shadow-lg p-8 mb-8 glow-effect border-2 border-primary"
         >
           <div class="flex items-center justify-between mb-6">
             <div class="flex items-center space-x-4">
               <div
-                class="bg-gradient-to-r from-amber-500 to-amber-600 text-white px-4 py-2 rounded-lg font-bold text-xl"
+                class="bg-gradient-to-r from-primary to-secondary text-white px-4 py-2 rounded-lg font-bold text-xl"
               >
-                Unreleased
+                v1.3.0
               </div>
-              <span class="text-gray-500 text-sm">In Development</span>
+              <span class="text-gray-500 text-sm">2025-01-09</span>
             </div>
-            <span class="badge bg-amber-100 text-amber-800">🚀 Coming Soon</span>
+            <span class="badge bg-green-100 text-green-800">Latest Release</span>
           </div>
 
           <div class="space-y-6">
@@ -347,18 +347,18 @@
 
         <!-- Version 1.2.0 -->
         <div
-          class="version-card bg-white rounded-xl shadow-lg p-8 mb-8 glow-effect border-2 border-primary"
+          class="version-card bg-white rounded-xl shadow-lg p-8 mb-8"
         >
           <div class="flex items-center justify-between mb-6">
             <div class="flex items-center space-x-4">
               <div
-                class="bg-gradient-to-r from-primary to-secondary text-white px-4 py-2 rounded-lg font-bold text-xl"
+                class="bg-gray-800 text-white px-4 py-2 rounded-lg font-bold text-xl"
               >
                 v1.2.0
               </div>
               <span class="text-gray-500 text-sm">2025-01-09</span>
             </div>
-            <span class="badge bg-green-100 text-green-800">Latest Release</span>
+            <span class="badge bg-blue-100 text-blue-800">Previous Release</span>
           </div>
 
           <div class="space-y-6">

--- a/public/changelog.html
+++ b/public/changelog.html
@@ -255,6 +255,96 @@
     <!-- Changelog Versions -->
     <section class="py-16">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <!-- Unreleased -->
+        <div
+          class="version-card bg-white rounded-xl shadow-lg p-8 mb-8 glow-effect border-2 border-amber-500"
+        >
+          <div class="flex items-center justify-between mb-6">
+            <div class="flex items-center space-x-4">
+              <div
+                class="bg-gradient-to-r from-amber-500 to-amber-600 text-white px-4 py-2 rounded-lg font-bold text-xl"
+              >
+                Unreleased
+              </div>
+              <span class="text-gray-500 text-sm">In Development</span>
+            </div>
+            <span class="badge bg-amber-100 text-amber-800">🚀 Coming Soon</span>
+          </div>
+
+          <div class="space-y-6">
+            <div>
+              <h3 class="text-lg font-semibold text-gray-900 mb-3">
+                <span class="badge badge-added mr-2">Added</span>
+              </h3>
+              <ul class="space-y-2 ml-4">
+                <li class="text-gray-700">
+                  <i class="fas fa-check-circle text-green-600 mr-2"></i>Manual standup trigger commands for admins and organization owners
+                </li>
+                <li class="text-gray-700 ml-6">
+                  <i class="fas fa-terminal text-primary mr-2"></i><code class="text-sm bg-gray-100 px-2 py-1 rounded">/dd-standup-remind [team-name]</code> - Send standup reminders to team members
+                </li>
+                <li class="text-gray-700 ml-6">
+                  <i class="fas fa-terminal text-primary mr-2"></i><code class="text-sm bg-gray-100 px-2 py-1 rounded">/dd-standup-post [YYYY-MM-DD] [team-name]</code> - Post standup summary for specific date
+                </li>
+                <li class="text-gray-700 ml-6">
+                  <i class="fas fa-terminal text-primary mr-2"></i><code class="text-sm bg-gray-100 px-2 py-1 rounded">/dd-standup-preview [YYYY-MM-DD] [team-name]</code> - Preview standup summary (ephemeral)
+                </li>
+                <li class="text-gray-700 ml-6">
+                  <i class="fas fa-terminal text-primary mr-2"></i><code class="text-sm bg-gray-100 px-2 py-1 rounded">/dd-standup-followup [team-name]</code> - Send followup reminders to non-responders
+                </li>
+                <li class="text-gray-700">
+                  <i class="fas fa-check-circle text-green-600 mr-2"></i>Permission system with role-based access control
+                </li>
+                <li class="text-gray-700 ml-6">
+                  <i class="fas fa-code text-primary mr-2"></i><code class="text-xs">permissionHelper.js</code> utility for checking Organization Owner and Team Admin roles
+                </li>
+                <li class="text-gray-700 ml-6">
+                  <i class="fas fa-code text-primary mr-2"></i><code class="text-xs">isOrganizationOwner()</code>, <code class="text-xs">isTeamAdmin()</code>, and <code class="text-xs">canManageTeam()</code> functions
+                </li>
+                <li class="text-gray-700">
+                  <i class="fas fa-check-circle text-green-600 mr-2"></i>Context-aware team resolution in <code class="text-xs">teamHelper.js</code>
+                </li>
+                <li class="text-gray-700 ml-6">
+                  <i class="fas fa-user-shield text-primary mr-2"></i>Admins can run commands from team channel without specifying team name
+                </li>
+                <li class="text-gray-700 ml-6">
+                  <i class="fas fa-crown text-amber-500 mr-2"></i>Owners must specify team name when running from any location
+                </li>
+                <li class="text-gray-700 ml-6">
+                  <i class="fas fa-code text-primary mr-2"></i><code class="text-xs">resolveTeamFromContext()</code> function for automatic team detection
+                </li>
+                <li class="text-gray-700 ml-6">
+                  <i class="fas fa-code text-primary mr-2"></i><code class="text-xs">parseCommandArguments()</code> for flexible date and team name parsing
+                </li>
+                <li class="text-gray-700">
+                  <i class="fas fa-check-circle text-green-600 mr-2"></i>Block helper functions for formatted command responses
+                </li>
+                <li class="text-gray-700 ml-6">
+                  <i class="fas fa-code text-primary mr-2"></i><code class="text-xs">createCommandSuccessBlocks()</code> - Success messages with details
+                </li>
+                <li class="text-gray-700 ml-6">
+                  <i class="fas fa-code text-primary mr-2"></i><code class="text-xs">createCommandErrorBlocks()</code> - Error messages with suggestions
+                </li>
+                <li class="text-gray-700 ml-6">
+                  <i class="fas fa-code text-primary mr-2"></i><code class="text-xs">createPermissionDeniedBlocks()</code> - Permission error messages
+                </li>
+                <li class="text-gray-700 ml-6">
+                  <i class="fas fa-code text-primary mr-2"></i><code class="text-xs">createStandupPreviewHeaderBlocks()</code> - Preview header formatting
+                </li>
+                <li class="text-gray-700 ml-6">
+                  <i class="fas fa-code text-primary mr-2"></i><code class="text-xs">createNoDataBlocks()</code> - No data available messages
+                </li>
+                <li class="text-gray-700">
+                  <i class="fas fa-check-circle text-green-600 mr-2"></i>Comprehensive audit logging for all admin actions
+                </li>
+                <li class="text-gray-700">
+                  <i class="fas fa-check-circle text-green-600 mr-2"></i>User stories and implementation plan documentation
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
         <!-- Version 1.2.0 -->
         <div
           class="version-card bg-white rounded-xl shadow-lg p-8 mb-8 glow-effect border-2 border-primary"

--- a/public/docs.html
+++ b/public/docs.html
@@ -922,6 +922,176 @@
                 </div>
               </div>
 
+              <div class="bg-white rounded-lg border p-6 border-l-4 border-l-amber-500">
+                <div class="flex items-center mb-4">
+                  <h3 class="font-semibold text-gray-900">
+                    Manual Standup Trigger Commands
+                  </h3>
+                  <span class="ml-3 px-3 py-1 bg-amber-100 text-amber-800 text-xs font-semibold rounded-full">
+                    ⚠️ ADMIN/OWNER ONLY
+                  </span>
+                </div>
+                <p class="text-gray-600 mb-4">
+                  Organization owners and team admins can manually trigger standup operations. These commands provide manual control over automated standup workflows while maintaining proper permission boundaries.
+                </p>
+
+                <!-- Remind Command -->
+                <div class="mb-6">
+                  <h4 class="font-semibold text-gray-800 mb-3">
+                    <i class="fas fa-bell text-amber-500 mr-2"></i>Send Standup Reminders
+                  </h4>
+                  <p class="text-sm text-gray-600 mb-3">
+                    Manually send standup reminders to all active team members who haven't submitted their standup yet.
+                  </p>
+                  <div class="space-y-2">
+                    <div class="code-block p-3 relative">
+                      <code class="text-amber-400">/dd-standup-remind</code>
+                      <span class="text-gray-400 ml-2"># Admin in team channel</span>
+                      <button
+                        class="copy-button absolute top-2 right-2 bg-gray-700 hover:bg-gray-600 text-white px-2 py-1 rounded text-xs"
+                        onclick="copyToClipboard('/dd-standup-remind')"
+                      >
+                        <i class="fas fa-copy"></i>
+                      </button>
+                    </div>
+                    <div class="code-block p-3 relative">
+                      <code class="text-amber-400">/dd-standup-remind Engineering Team</code>
+                      <span class="text-gray-400 ml-2"># Owner specifies team</span>
+                      <button
+                        class="copy-button absolute top-2 right-2 bg-gray-700 hover:bg-gray-600 text-white px-2 py-1 rounded text-xs"
+                        onclick="copyToClipboard('/dd-standup-remind Engineering Team')"
+                      >
+                        <i class="fas fa-copy"></i>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Post Command -->
+                <div class="mb-6">
+                  <h4 class="font-semibold text-gray-800 mb-3">
+                    <i class="fas fa-paper-plane text-amber-500 mr-2"></i>Post Standup Summary
+                  </h4>
+                  <p class="text-sm text-gray-600 mb-3">
+                    Manually post the standup summary to the team channel. Includes all responses and late submissions. Optional date parameter for historical standups.
+                  </p>
+                  <div class="space-y-2">
+                    <div class="code-block p-3 relative">
+                      <code class="text-amber-400">/dd-standup-post</code>
+                      <span class="text-gray-400 ml-2"># Post today's standup</span>
+                      <button
+                        class="copy-button absolute top-2 right-2 bg-gray-700 hover:bg-gray-600 text-white px-2 py-1 rounded text-xs"
+                        onclick="copyToClipboard('/dd-standup-post')"
+                      >
+                        <i class="fas fa-copy"></i>
+                      </button>
+                    </div>
+                    <div class="code-block p-3 relative">
+                      <code class="text-amber-400">/dd-standup-post 2025-01-15</code>
+                      <span class="text-gray-400 ml-2"># Post specific date</span>
+                      <button
+                        class="copy-button absolute top-2 right-2 bg-gray-700 hover:bg-gray-600 text-white px-2 py-1 rounded text-xs"
+                        onclick="copyToClipboard('/dd-standup-post 2025-01-15')"
+                      >
+                        <i class="fas fa-copy"></i>
+                      </button>
+                    </div>
+                    <div class="code-block p-3 relative">
+                      <code class="text-amber-400">/dd-standup-post Marketing Team</code>
+                      <span class="text-gray-400 ml-2"># Owner posts for team</span>
+                      <button
+                        class="copy-button absolute top-2 right-2 bg-gray-700 hover:bg-gray-600 text-white px-2 py-1 rounded text-xs"
+                        onclick="copyToClipboard('/dd-standup-post Marketing Team')"
+                      >
+                        <i class="fas fa-copy"></i>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Preview Command -->
+                <div class="mb-6">
+                  <h4 class="font-semibold text-gray-800 mb-3">
+                    <i class="fas fa-eye text-amber-500 mr-2"></i>Preview Standup Summary
+                  </h4>
+                  <p class="text-sm text-gray-600 mb-3">
+                    Preview the standup summary as an ephemeral message (only visible to you) before posting it publicly.
+                  </p>
+                  <div class="space-y-2">
+                    <div class="code-block p-3 relative">
+                      <code class="text-amber-400">/dd-standup-preview</code>
+                      <span class="text-gray-400 ml-2"># Preview today's standup</span>
+                      <button
+                        class="copy-button absolute top-2 right-2 bg-gray-700 hover:bg-gray-600 text-white px-2 py-1 rounded text-xs"
+                        onclick="copyToClipboard('/dd-standup-preview')"
+                      >
+                        <i class="fas fa-copy"></i>
+                      </button>
+                    </div>
+                    <div class="code-block p-3 relative">
+                      <code class="text-amber-400">/dd-standup-preview 2025-01-15</code>
+                      <span class="text-gray-400 ml-2"># Preview specific date</span>
+                      <button
+                        class="copy-button absolute top-2 right-2 bg-gray-700 hover:bg-gray-600 text-white px-2 py-1 rounded text-xs"
+                        onclick="copyToClipboard('/dd-standup-preview 2025-01-15')"
+                      >
+                        <i class="fas fa-copy"></i>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Followup Command -->
+                <div class="mb-6">
+                  <h4 class="font-semibold text-gray-800 mb-3">
+                    <i class="fas fa-redo text-amber-500 mr-2"></i>Send Followup Reminders
+                  </h4>
+                  <p class="text-sm text-gray-600 mb-3">
+                    Send followup reminders to team members who haven't submitted their standup yet.
+                  </p>
+                  <div class="space-y-2">
+                    <div class="code-block p-3 relative">
+                      <code class="text-amber-400">/dd-standup-followup</code>
+                      <span class="text-gray-400 ml-2"># Admin in team channel</span>
+                      <button
+                        class="copy-button absolute top-2 right-2 bg-gray-700 hover:bg-gray-600 text-white px-2 py-1 rounded text-xs"
+                        onclick="copyToClipboard('/dd-standup-followup')"
+                      >
+                        <i class="fas fa-copy"></i>
+                      </button>
+                    </div>
+                    <div class="code-block p-3 relative">
+                      <code class="text-amber-400">/dd-standup-followup Product Team</code>
+                      <span class="text-gray-400 ml-2"># Owner specifies team</span>
+                      <button
+                        class="copy-button absolute top-2 right-2 bg-gray-700 hover:bg-gray-600 text-white px-2 py-1 rounded text-xs"
+                        onclick="copyToClipboard('/dd-standup-followup Product Team')"
+                      >
+                        <i class="fas fa-copy"></i>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Permission Info -->
+                <div class="bg-amber-50 border border-amber-200 rounded p-4">
+                  <h4 class="font-semibold text-amber-900 mb-2">
+                    <i class="fas fa-shield-alt mr-2"></i>Context-Aware Behavior:
+                  </h4>
+                  <ul class="text-sm text-amber-800 space-y-2">
+                    <li>
+                      <i class="fas fa-user-shield mr-2"></i><strong>Team Admins:</strong> Can run commands from their team's channel without specifying team name
+                    </li>
+                    <li>
+                      <i class="fas fa-crown mr-2"></i><strong>Organization Owners:</strong> Must specify team name when running from any channel
+                    </li>
+                    <li>
+                      <i class="fas fa-ban mr-2"></i><strong>Regular Members:</strong> Cannot use these commands (permission denied)
+                    </li>
+                  </ul>
+                </div>
+              </div>
+
               <div class="bg-white rounded-lg border p-6">
                 <h3 class="font-semibold text-gray-900 mb-4">
                   Standup Reminder Preferences

--- a/slack-app-manifest.json
+++ b/slack-app-manifest.json
@@ -121,6 +121,34 @@
                 "should_escape": false
             },
             {
+                "command": "/dd-standup-remind",
+                "url": "{{APP_URL}}/slack/events",
+                "description": "Send standup reminders to team members (admin/owner)",
+                "usage_hint": "[team-name]",
+                "should_escape": false
+            },
+            {
+                "command": "/dd-standup-post",
+                "url": "{{APP_URL}}/slack/events",
+                "description": "Post standup summary to channel (admin/owner)",
+                "usage_hint": "[YYYY-MM-DD] [team-name]",
+                "should_escape": false
+            },
+            {
+                "command": "/dd-standup-preview",
+                "url": "{{APP_URL}}/slack/events",
+                "description": "Preview standup summary before posting (admin/owner)",
+                "usage_hint": "[YYYY-MM-DD] [team-name]",
+                "should_escape": false
+            },
+            {
+                "command": "/dd-standup-followup",
+                "url": "{{APP_URL}}/slack/events",
+                "description": "Send followup reminders to non-responders (admin/owner)",
+                "usage_hint": "[team-name]",
+                "should_escape": false
+            },
+            {
                 "command": "/dd-holiday-set",
                 "url": "{{APP_URL}}/slack/events",
                 "description": "Set holidays for single day or date range (admin only)",

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -10,6 +10,12 @@ function setupCommands(app) {
   app.command("/dd-standup", stripFormatting(), standupCommands.submitManual);
   app.command("/dd-standup-update", stripFormatting(), standupCommands.updateStandup);
 
+  // Admin/Owner standup management commands - wrapped with formatting removal middleware
+  app.command("/dd-standup-remind", stripFormatting(), standupCommands.sendReminders);
+  app.command("/dd-standup-post", stripFormatting(), standupCommands.postStandup);
+  app.command("/dd-standup-preview", stripFormatting(), standupCommands.previewStandup);
+  app.command("/dd-standup-followup", stripFormatting(), standupCommands.sendFollowupReminders);
+
   // Team management commands - wrapped with formatting removal middleware
   app.command("/dd-team-list", stripFormatting(), teamCommands.listTeams);
   app.command("/dd-team-join", stripFormatting(), teamCommands.joinTeam);

--- a/src/utils/blockHelper.js
+++ b/src/utils/blockHelper.js
@@ -470,6 +470,141 @@ function createStandupUpdateModal(teamName, teamId, today, standupDate, existing
   };
 }
 
+/**
+ * Create command success response blocks
+ * @param {string} message - Success message text
+ * @param {object} details - Optional details object with additional info
+ * @returns {Array<object>} Array of blocks for success response
+ */
+function createCommandSuccessBlocks(message, details = null) {
+  const blocks = [
+    createSectionBlock(`✅ ${message}`),
+  ];
+
+  if (details) {
+    const detailsText = Object.entries(details)
+      .map(([key, value]) => `• *${key}:* ${value}`)
+      .join("\n");
+
+    blocks.push({
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: detailsText,
+        },
+      ],
+    });
+  }
+
+  return blocks;
+}
+
+/**
+ * Create command error response blocks
+ * @param {string} message - Error message text
+ * @param {Array<string>} suggestions - Optional array of suggestion strings
+ * @returns {Array<object>} Array of blocks for error response
+ */
+function createCommandErrorBlocks(message, suggestions = null) {
+  const blocks = [
+    createSectionBlock(`❌ ${message}`),
+  ];
+
+  if (suggestions && suggestions.length > 0) {
+    const suggestionsText = suggestions
+      .map((s, i) => `${i + 1}. ${s}`)
+      .join("\n");
+
+    blocks.push(
+      createDividerBlock(),
+      createSectionBlock(`*💡 Suggestions:*\n${suggestionsText}`)
+    );
+  }
+
+  return blocks;
+}
+
+/**
+ * Create permission denied response blocks
+ * @param {string} requiredRole - The required role (ADMIN or OWNER)
+ * @returns {Array<object>} Array of blocks for permission denied response
+ */
+function createPermissionDeniedBlocks(requiredRole = "ADMIN") {
+  const roleText = requiredRole === "OWNER"
+    ? "organization owner"
+    : "team admin or organization owner";
+
+  return [
+    createSectionBlock(`❌ *Permission Denied*`),
+    createSectionBlock(`You need to be a ${roleText} to use this command.`),
+    {
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: "_Contact your team admin or organization owner for help._",
+        },
+      ],
+    },
+  ];
+}
+
+/**
+ * Create standup preview header blocks
+ * @param {string} teamName - Team name
+ * @param {string} date - Date string
+ * @param {boolean} isToday - Whether the preview is for today
+ * @returns {Array<object>} Array of blocks for preview header
+ */
+function createStandupPreviewHeaderBlocks(teamName, date, isToday = true) {
+  const dateLabel = isToday ? "Today" : date;
+
+  return [
+    {
+      type: "header",
+      text: {
+        type: "plain_text",
+        text: `🔍 Standup Preview - ${teamName}`,
+      },
+    },
+    createSectionBlock(`*📅 ${dateLabel}*`),
+    {
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: "_This is a preview. Use `/dd-standup-post` to publish this standup._",
+        },
+      ],
+    },
+    createDividerBlock(),
+  ];
+}
+
+/**
+ * Create no data available blocks
+ * @param {string} context - Context of what data is missing (e.g., "standup responses")
+ * @param {string} date - Optional date string
+ * @returns {Array<object>} Array of blocks for no data message
+ */
+function createNoDataBlocks(context = "data", date = null) {
+  const dateText = date ? ` for ${date}` : "";
+
+  return [
+    createSectionBlock(`⚠️ *No ${context} found${dateText}*`),
+    {
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: "_Team members haven't submitted any responses yet._",
+        },
+      ],
+    },
+  ];
+}
+
 module.exports = {
   createSectionBlock,
   createFieldsBlock,
@@ -488,4 +623,9 @@ module.exports = {
   createTeamSelectionBlocks,
   createErrorBlocks,
   createSuccessBlocks,
+  createCommandSuccessBlocks,
+  createCommandErrorBlocks,
+  createPermissionDeniedBlocks,
+  createStandupPreviewHeaderBlocks,
+  createNoDataBlocks,
 };

--- a/src/utils/permissionHelper.js
+++ b/src/utils/permissionHelper.js
@@ -1,0 +1,130 @@
+const prisma = require("../config/prisma");
+
+/**
+ * Check if a user is the owner of an organization
+ * @param {number} userId - The user ID to check
+ * @param {number} organizationId - The organization ID to check against
+ * @returns {Promise<boolean>} True if user is the organization owner
+ */
+async function isOrganizationOwner(userId, organizationId) {
+  try {
+    const organization = await prisma.organization.findUnique({
+      where: { id: organizationId },
+      select: { createdBy: true },
+    });
+
+    return organization && organization.createdBy === userId;
+  } catch (error) {
+    console.error("Error checking organization owner:", error);
+    return false;
+  }
+}
+
+/**
+ * Check if a user is an admin of a specific team
+ * @param {number} userId - The user ID to check
+ * @param {number} teamId - The team ID to check against
+ * @returns {Promise<boolean>} True if user is a team admin
+ */
+async function isTeamAdmin(userId, teamId) {
+  try {
+    const teamMember = await prisma.teamMember.findFirst({
+      where: {
+        userId,
+        teamId,
+        isActive: true,
+        role: "ADMIN",
+      },
+    });
+
+    return !!teamMember;
+  } catch (error) {
+    console.error("Error checking team admin:", error);
+    return false;
+  }
+}
+
+/**
+ * Check if a user can manage a team (either as owner or admin)
+ * @param {number} userId - The user ID to check
+ * @param {number} teamId - The team ID to check against
+ * @returns {Promise<{canManage: boolean, role: string|null, reason: string|null}>} Permission result with role information
+ */
+async function canManageTeam(userId, teamId) {
+  try {
+    // Get team with organization info
+    const team = await prisma.team.findUnique({
+      where: { id: teamId },
+      select: { organizationId: true },
+    });
+
+    if (!team) {
+      return {
+        canManage: false,
+        role: null,
+        reason: "Team not found",
+      };
+    }
+
+    // Check if user is organization owner
+    const isOwner = await isOrganizationOwner(userId, team.organizationId);
+    if (isOwner) {
+      return {
+        canManage: true,
+        role: "OWNER",
+        reason: null,
+      };
+    }
+
+    // Check if user is team admin
+    const isAdmin = await isTeamAdmin(userId, teamId);
+    if (isAdmin) {
+      return {
+        canManage: true,
+        role: "ADMIN",
+        reason: null,
+      };
+    }
+
+    return {
+      canManage: false,
+      role: null,
+      reason: "User is not an admin or owner",
+    };
+  } catch (error) {
+    console.error("Error checking team management permission:", error);
+    return {
+      canManage: false,
+      role: null,
+      reason: "Error checking permissions",
+    };
+  }
+}
+
+/**
+ * Get user by Slack user ID
+ * @param {string} slackUserId - The Slack user ID
+ * @returns {Promise<object|null>} User object or null if not found
+ */
+async function getUserBySlackId(slackUserId) {
+  try {
+    const user = await prisma.user.findUnique({
+      where: { slackUserId },
+      include: {
+        organization: true,
+      },
+    });
+
+    return user;
+  } catch (error) {
+    console.error("Error fetching user by Slack ID:", error);
+    return null;
+  }
+}
+
+module.exports = {
+  isOrganizationOwner,
+  isTeamAdmin,
+  canManageTeam,
+  getUserBySlackId,
+};

--- a/src/utils/permissionHelper.js
+++ b/src/utils/permissionHelper.js
@@ -53,8 +53,8 @@ async function isTeamAdmin(userId, teamId) {
 async function canManageTeam(userId, teamId) {
   try {
     // Get team with organization info
-    const team = await prisma.team.findUnique({
-      where: { id: teamId },
+    const team = await prisma.team.findFirst({
+      where: { id: teamId, isActive: true },
       select: { organizationId: true },
     });
 

--- a/src/utils/teamHelper.js
+++ b/src/utils/teamHelper.js
@@ -1,0 +1,236 @@
+const prisma = require("../config/prisma");
+
+/**
+ * Resolve team from context (channel or team name)
+ * Context-aware resolution:
+ * - If teamName is provided, find team by name
+ * - If no teamName but channelId provided, find team by channel
+ * - Returns null if team not found
+ *
+ * @param {string|null} channelId - The Slack channel ID (optional)
+ * @param {string|null} teamName - The team name to search for (optional)
+ * @param {number|null} userId - The user ID for additional context (optional)
+ * @returns {Promise<{team: object|null, error: string|null}>} Team object and error message
+ */
+async function resolveTeamFromContext(channelId = null, teamName = null, userId = null) {
+  try {
+    let team = null;
+
+    // Priority 1: If team name is provided, search by name
+    if (teamName && teamName.trim()) {
+      team = await prisma.team.findFirst({
+        where: {
+          name: {
+            equals: teamName.trim(),
+            mode: "insensitive",
+          },
+          isActive: true,
+        },
+        include: {
+          organization: true,
+        },
+      });
+
+      if (!team) {
+        return {
+          team: null,
+          error: `Team "${teamName}" not found. Please check the team name and try again.`,
+        };
+      }
+
+      return { team, error: null };
+    }
+
+    // Priority 2: If no team name, try to find by channel ID
+    if (channelId) {
+      team = await prisma.team.findFirst({
+        where: {
+          slackChannelId: channelId,
+          isActive: true,
+        },
+        include: {
+          organization: true,
+        },
+      });
+
+      if (!team) {
+        return {
+          team: null,
+          error: "This channel is not associated with any team. Please provide a team name.",
+        };
+      }
+
+      return { team, error: null };
+    }
+
+    // No context provided
+    return {
+      team: null,
+      error: "Please provide a team name or run this command in a team channel.",
+    };
+  } catch (error) {
+    console.error("Error resolving team from context:", error);
+    return {
+      team: null,
+      error: "An error occurred while finding the team. Please try again.",
+    };
+  }
+}
+
+/**
+ * Get all teams for an organization
+ * @param {number} organizationId - The organization ID
+ * @returns {Promise<Array<object>>} Array of team objects
+ */
+async function getTeamsByOrganization(organizationId) {
+  try {
+    const teams = await prisma.team.findMany({
+      where: {
+        organizationId,
+        isActive: true,
+      },
+      include: {
+        _count: {
+          select: {
+            members: {
+              where: { isActive: true },
+            },
+          },
+        },
+      },
+      orderBy: {
+        name: "asc",
+      },
+    });
+
+    return teams;
+  } catch (error) {
+    console.error("Error fetching teams by organization:", error);
+    return [];
+  }
+}
+
+/**
+ * Get team by ID with full details
+ * @param {number} teamId - The team ID
+ * @returns {Promise<object|null>} Team object or null
+ */
+async function getTeamById(teamId) {
+  try {
+    const team = await prisma.team.findUnique({
+      where: {
+        id: teamId,
+        isActive: true,
+      },
+      include: {
+        organization: true,
+      },
+    });
+
+    return team;
+  } catch (error) {
+    console.error("Error fetching team by ID:", error);
+    return null;
+  }
+}
+
+/**
+ * Parse team name from command text
+ * Handles team names with or without quotes
+ * @param {string} commandText - The command text to parse
+ * @returns {string|null} Parsed team name or null
+ */
+function parseTeamName(commandText) {
+  if (!commandText || !commandText.trim()) {
+    return null;
+  }
+
+  const text = commandText.trim();
+
+  // Check if text is wrapped in quotes
+  const quotedMatch = text.match(/^["'](.+)["']$/);
+  if (quotedMatch) {
+    return quotedMatch[1];
+  }
+
+  // Return the text as-is (might be multi-word without quotes)
+  return text;
+}
+
+/**
+ * Parse command arguments for date and team name
+ * Supports formats:
+ * - "team name"
+ * - 2025-01-15
+ * - 2025-01-15 "team name"
+ * - "team name" 2025-01-15
+ *
+ * @param {string} commandText - The command text to parse
+ * @returns {{date: string|null, teamName: string|null}} Parsed date and team name
+ */
+function parseCommandArguments(commandText) {
+  if (!commandText || !commandText.trim()) {
+    return { date: null, teamName: null };
+  }
+
+  const text = commandText.trim();
+  let date = null;
+  let teamName = null;
+
+  // Date pattern: YYYY-MM-DD
+  const datePattern = /\b(\d{4}-\d{2}-\d{2})\b/;
+  const dateMatch = text.match(datePattern);
+
+  if (dateMatch) {
+    date = dateMatch[1];
+    // Remove date from text to extract team name
+    const remainingText = text.replace(dateMatch[0], "").trim();
+    if (remainingText) {
+      teamName = parseTeamName(remainingText);
+    }
+  } else {
+    // No date, entire text is team name
+    teamName = parseTeamName(text);
+  }
+
+  return { date, teamName };
+}
+
+/**
+ * Validate date format (YYYY-MM-DD)
+ * @param {string} dateStr - The date string to validate
+ * @returns {{isValid: boolean, error: string|null}} Validation result
+ */
+function validateDateFormat(dateStr) {
+  if (!dateStr) {
+    return { isValid: true, error: null };
+  }
+
+  const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+  if (!datePattern.test(dateStr)) {
+    return {
+      isValid: false,
+      error: "Invalid date format. Please use YYYY-MM-DD format (e.g., 2025-01-15).",
+    };
+  }
+
+  // Check if date is valid
+  const date = new Date(dateStr);
+  if (isNaN(date.getTime())) {
+    return {
+      isValid: false,
+      error: "Invalid date. Please provide a valid date in YYYY-MM-DD format.",
+    };
+  }
+
+  return { isValid: true, error: null };
+}
+
+module.exports = {
+  resolveTeamFromContext,
+  getTeamsByOrganization,
+  getTeamById,
+  parseTeamName,
+  parseCommandArguments,
+  validateDateFormat,
+};

--- a/src/utils/teamHelper.js
+++ b/src/utils/teamHelper.js
@@ -117,7 +117,7 @@ async function getTeamsByOrganization(organizationId) {
  */
 async function getTeamById(teamId) {
   try {
-    const team = await prisma.team.findUnique({
+    const team = await prisma.team.findFirst({
       where: {
         id: teamId,
         isActive: true,
@@ -131,6 +131,8 @@ async function getTeamById(teamId) {
   } catch (error) {
     console.error("Error fetching team by ID:", error);
     return null;
+  }
+}
   }
 }
 


### PR DESCRIPTION
## Summary
Introduces four new slash commands that enable organization owners and team admins to manually trigger standup operations. Commands include sending reminders, posting summaries, previewing summaries, and sending followup reminders to non-responders.

## Changes Made
- Add `/dd-standup-remind` - Send standup reminders to team members
- Add `/dd-standup-post` - Post standup summary for a specific date  
- Add `/dd-standup-preview` - Preview standup summary before posting (ephemeral)
- Add `/dd-standup-followup` - Send followup reminders to non-responders
- New `permissionHelper.js` utility for role-based access control (Organization Owner, Team Admin)
- New `teamHelper.js` utility for context-aware team resolution (by channel or team name)
- Five new block helper functions for formatted command responses
- Updated Slack manifest with new commands
- Enhanced CLAUDE.md and README.md with documentation

## Key Features
- **Role-based permissions**: Commands enforce Organization Owner and Team Admin roles
- **Context-aware team resolution**: Team admins use current channel, owners specify team name  
- **Formatted responses**: User-friendly block kit messages with clear guidance
- **Comprehensive audit logging**: All admin actions logged with user identifiers
- **Error handling**: Helpful error messages with usage suggestions

## Testing Checklist
- [ ] Test `/dd-standup-remind` as team admin (use current channel)
- [ ] Test `/dd-standup-remind` as org owner with team name parameter
- [ ] Test `/dd-standup-preview` returns ephemeral message
- [ ] Test `/dd-standup-post` posts summary to team channel
- [ ] Test `/dd-standup-followup` sends reminders to non-responders
- [ ] Verify permission denied for non-admin users
- [ ] Verify clear error messages for invalid teams

## Breaking Changes
None - all new commands, backward compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added four admin/owner-only slash commands to manually trigger standup actions: remind, post, preview, and follow-up (support optional team and date YYYY‑MM‑DD).
  * Commands use context-aware team resolution and role-based permission checks (Team Admins or Organization Owners).
  * Standardized command response blocks for success, errors, permission denials, and previews.

* **Documentation**
  * Added comprehensive guides, user stories, implementation plan, examples, and changelog entries for the manual standup commands (documentation content appears duplicated in places).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->