### PR TITLE
feat: team and organization member suspension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Suspension is implemented by toggling `TeamMember.isActive` / `OrganizationMember.isActive` — no new schema or migration required
   - Service layer: `teamService.setTeamMemberActive()` and `userService.setOrganizationMemberActive()` enforce permission checks and prevent self-suspension, suspending the only active team admin (per-team and org-wide), non-owners changing an owner's status, and team-reactivating a user who is currently org-suspended
   - Cascade and org-membership update wrapped in a Prisma transaction
+- Auto-suspension when a Slack workspace user is deactivated
+  - New `user_change` bot event subscription (`slack-app-manifest.json`)
+  - `src/events/index.js` handles the event; when `event.user.deleted === true` calls `userService.suspendUserSystemWide(slackUserId)` which deactivates every active `OrganizationMember` and `TeamMember` row for that user across all orgs
+  - System-triggered path bypasses admin-permission and sole-active-admin guards — the deactivated Slack user can no longer act, so suspension must apply regardless
+  - Idempotent (only touches `isActive: true` rows); no-op when the Slack user isn't in our DB
   - Commands registered in `src/commands/index.js`; slash commands added to `slack-app-manifest.json`
 
 ## [1.5.1] - 2026-04-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Member suspension feature
   - `/dd-team-suspend @user [TeamName]` — team admin (or org owner/admin) can suspend a member from a single team; falls back to channel's team when no name given
   - `/dd-team-unsuspend @user [TeamName]` — reactivate a suspended team member
-  - `/dd-org-suspend @user` — org owner/admin suspends a member across the entire organization (cascades to all `TeamMember` rows in that org)
-  - `/dd-org-unsuspend @user` — reactivate org-wide; also reactivates the user's team memberships within the org
+  - `/dd-org-suspend @user` — org owner/admin suspends a member across the entire organization (cascades to currently-active `TeamMember` rows in that org)
+  - `/dd-org-unsuspend @user` — reactivates the user's `OrganizationMember` only; does **not** resurrect team memberships (admin must use `/dd-team-unsuspend` per team) to avoid silently re-adding users who had left or been team-suspended independently
   - Suspension is implemented by toggling `TeamMember.isActive` / `OrganizationMember.isActive` — no new schema or migration required
-  - Service layer: `teamService.setTeamMemberActive()` and `userService.setOrganizationMemberActive()` enforce permission checks and prevent self-suspension, suspending the only active team admin, or non-owners suspending an owner
-  - Org-level cascade wraps both updates in a Prisma transaction
+  - Service layer: `teamService.setTeamMemberActive()` and `userService.setOrganizationMemberActive()` enforce permission checks and prevent self-suspension, suspending the only active team admin (per-team and org-wide), non-owners changing an owner's status, and team-reactivating a user who is currently org-suspended
+  - Cascade and org-membership update wrapped in a Prisma transaction
   - Commands registered in `src/commands/index.js`; slash commands added to `slack-app-manifest.json`
 
 ## [1.5.1] - 2026-04-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Member suspension feature
+  - `/dd-team-suspend @user [TeamName]` — team admin (or org owner/admin) can suspend a member from a single team; falls back to channel's team when no name given
+  - `/dd-team-unsuspend @user [TeamName]` — reactivate a suspended team member
+  - `/dd-org-suspend @user` — org owner/admin suspends a member across the entire organization (cascades to all `TeamMember` rows in that org)
+  - `/dd-org-unsuspend @user` — reactivate org-wide; also reactivates the user's team memberships within the org
+  - Suspension is implemented by toggling `TeamMember.isActive` / `OrganizationMember.isActive` — no new schema or migration required
+  - Service layer: `teamService.setTeamMemberActive()` and `userService.setOrganizationMemberActive()` enforce permission checks and prevent self-suspension, suspending the only active team admin, or non-owners suspending an owner
+  - Org-level cascade wraps both updates in a Prisma transaction
+  - Commands registered in `src/commands/index.js`; slash commands added to `slack-app-manifest.json`
+
 ## [1.5.1] - 2026-04-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -379,10 +379,11 @@ These commands allow team admins and organization owners to manually trigger sta
   - **Name-based**: `/dd-team-suspend @john Engineering` (suspends from a specific team)
   - Suspended members stop receiving reminders, are excluded from standup posts, and cannot submit standups for that team
 - `/dd-team-unsuspend @user [team-name]` - Reactivate a suspended team member ⚠️ **(team admin or org owner/admin)**
-- `/dd-org-suspend @user` - Permanently suspend a member across the entire organization ⚠️ **(org owner/admin only)**
+- `/dd-org-suspend @user` - Suspend a member across the entire organization ⚠️ **(org owner/admin only)**
   - Cascades the suspension to every team in the organization
+  - Blocked if the user is the only active admin of any team in the org
 - `/dd-org-unsuspend @user` - Reactivate a suspended organization member ⚠️ **(org owner/admin only)**
-  - Restores org membership and the user's team memberships within the organization
+  - Restores org membership only; use `/dd-team-unsuspend` to re-add the user to specific teams
 
 ### 🌴 Leave Management
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ When you first interact with the bot, you'll be automatically added to your orga
 /dd-team-create MyTeam 09:30 10:00    # Create new team with custom name ⚠️ (admin only)
 /dd-team-update standup=09:00         # Update team in current channel ⚠️ (admin only)
 /dd-team-update Engineering standup=09:00  # Update specific team ⚠️ (admin only)
+/dd-team-suspend @user                # Suspend member from team in current channel ⚠️ (admin only)
+/dd-team-suspend @user Engineering    # Suspend member from a specific team ⚠️ (admin only)
+/dd-team-unsuspend @user [TeamName]   # Reactivate a suspended team member ⚠️ (admin only)
+/dd-org-suspend @user                 # Suspend member from entire organization ⚠️ (org owner/admin)
+/dd-org-unsuspend @user               # Reactivate suspended org member ⚠️ (org owner/admin)
 ```
 
 ### 3. Submit Your Daily Standup
@@ -369,6 +374,15 @@ These commands allow team admins and organization owners to manually trigger sta
   - **Name-based**: `/dd-team-update Engineering standup=09:00 posting=10:30 notifications=false` (updates specific team from any channel)
   - **Parameters**: `name=NewName`, `standup=HH:MM`, `posting=HH:MM`, `notifications=true/false`
   - The `notifications` parameter controls whether team admins receive standup submission notifications (default: true)
+- `/dd-team-suspend @user [team-name]` - Suspend a member from a team ⚠️ **(team admin or org owner/admin)**
+  - **Channel-based**: `/dd-team-suspend @john` (suspends from team in current channel)
+  - **Name-based**: `/dd-team-suspend @john Engineering` (suspends from a specific team)
+  - Suspended members stop receiving reminders, are excluded from standup posts, and cannot submit standups for that team
+- `/dd-team-unsuspend @user [team-name]` - Reactivate a suspended team member ⚠️ **(team admin or org owner/admin)**
+- `/dd-org-suspend @user` - Permanently suspend a member across the entire organization ⚠️ **(org owner/admin only)**
+  - Cascades the suspension to every team in the organization
+- `/dd-org-unsuspend @user` - Reactivate a suspended organization member ⚠️ **(org owner/admin only)**
+  - Restores org membership and the user's team memberships within the organization
 
 ### 🌴 Leave Management
 

--- a/slack-app-manifest.json
+++ b/slack-app-manifest.json
@@ -53,6 +53,34 @@
                 "should_escape": false
             },
             {
+                "command": "/dd-team-suspend",
+                "url": "{{APP_URL}}/slack/events",
+                "description": "Suspend a member from a team (admin only)",
+                "usage_hint": "@user [TeamName]",
+                "should_escape": false
+            },
+            {
+                "command": "/dd-team-unsuspend",
+                "url": "{{APP_URL}}/slack/events",
+                "description": "Reactivate a suspended team member (admin only)",
+                "usage_hint": "@user [TeamName]",
+                "should_escape": false
+            },
+            {
+                "command": "/dd-org-suspend",
+                "url": "{{APP_URL}}/slack/events",
+                "description": "Suspend a member from the entire organization (org owner/admin only)",
+                "usage_hint": "@user",
+                "should_escape": false
+            },
+            {
+                "command": "/dd-org-unsuspend",
+                "url": "{{APP_URL}}/slack/events",
+                "description": "Reactivate a suspended organization member (org owner/admin only)",
+                "usage_hint": "@user",
+                "should_escape": false
+            },
+            {
                 "command": "/dd-leave-set",
                 "url": "{{APP_URL}}/slack/events",
                 "description": "Set leave dates to skip standup reminders",

--- a/slack-app-manifest.json
+++ b/slack-app-manifest.json
@@ -249,7 +249,8 @@
                 "message.channels",
                 "message.groups",
                 "message.im",
-                "team_join"
+                "team_join",
+                "user_change"
             ]
         },
         "interactivity": {

--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,7 @@ const path = require("path");
 const prisma = require("./config/prisma");
 const { setupCommands } = require("./commands");
 const { setupWorkflows } = require("./workflows");
+const { setupEvents } = require("./events");
 const schedulerService = require("./services/schedulerService");
 
 const receiver = new ExpressReceiver({
@@ -18,6 +19,7 @@ const app = new App({
 // Setup commands and workflows
 setupCommands(app);
 setupWorkflows(app);
+setupEvents(app);
 
 // Initialize scheduler
 schedulerService.initialize(app);

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -24,6 +24,10 @@ function setupCommands(app) {
   app.command("/dd-team-members", stripFormatting(), teamCommands.listMembers);
   app.command("/dd-team-create", stripFormatting(), teamCommands.createTeam);
   app.command("/dd-team-update", stripFormatting(), teamCommands.updateTeam);
+  app.command("/dd-team-suspend", stripFormatting(), teamCommands.suspendTeamMember);
+  app.command("/dd-team-unsuspend", stripFormatting(), teamCommands.unsuspendTeamMember);
+  app.command("/dd-org-suspend", stripFormatting(), teamCommands.suspendOrgMember);
+  app.command("/dd-org-unsuspend", stripFormatting(), teamCommands.unsuspendOrgMember);
 
   // Leave management commands - wrapped with formatting removal middleware
   app.command("/dd-leave-list", stripFormatting(), leaveCommands.listLeaves);

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -24,10 +24,12 @@ function setupCommands(app) {
   app.command("/dd-team-members", stripFormatting(), teamCommands.listMembers);
   app.command("/dd-team-create", stripFormatting(), teamCommands.createTeam);
   app.command("/dd-team-update", stripFormatting(), teamCommands.updateTeam);
-  app.command("/dd-team-suspend", stripFormatting(), teamCommands.suspendTeamMember);
-  app.command("/dd-team-unsuspend", stripFormatting(), teamCommands.unsuspendTeamMember);
-  app.command("/dd-org-suspend", stripFormatting(), teamCommands.suspendOrgMember);
-  app.command("/dd-org-unsuspend", stripFormatting(), teamCommands.unsuspendOrgMember);
+  // Suspension commands accept @mentions; skip stripFormatting so the raw
+  // <@U...|name> wrapper survives for parseUserMention.
+  app.command("/dd-team-suspend", teamCommands.suspendTeamMember);
+  app.command("/dd-team-unsuspend", teamCommands.unsuspendTeamMember);
+  app.command("/dd-org-suspend", teamCommands.suspendOrgMember);
+  app.command("/dd-org-unsuspend", teamCommands.unsuspendOrgMember);
 
   // Leave management commands - wrapped with formatting removal middleware
   app.command("/dd-leave-list", stripFormatting(), leaveCommands.listLeaves);

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -63,7 +63,9 @@ function setupCommands(app) {
   app.view("standup_modal", standupCommands.handleStandupSubmission);
   app.view("standup_update_modal", standupCommands.handleStandupUpdateSubmission);
 
-  console.log("✅ Commands registered with formatting removal middleware");
+  console.log(
+    "✅ Commands registered (most with stripFormatting; suspension commands keep raw mentions)"
+  );
 }
 
 module.exports = { setupCommands };

--- a/src/commands/team.js
+++ b/src/commands/team.js
@@ -1,4 +1,5 @@
 const teamService = require("../services/teamService");
+const userService = require("../services/userService");
 const schedulerService = require("../services/schedulerService");
 const { ackWithProcessing, getChannelName } = require("../utils/commandHelper");
 const { getDisplayName } = require("../utils/userHelper");
@@ -7,6 +8,12 @@ const {
   createSectionBlock,
   createCommandErrorBlocks,
 } = require("../utils/blockHelper");
+
+function parseUserMention(token) {
+  if (!token) return null;
+  const match = token.match(/<@([A-Z0-9]+)(\|[^>]+)?>/);
+  return match ? match[1] : null;
+}
 
 async function createTeam({ command, ack, respond, client }) {
   const updateResponse = await ackWithProcessing(
@@ -473,6 +480,162 @@ async function updateTeam({ command, ack, respond, client }) {
   }
 }
 
+async function suspendTeamMember({ command, ack, respond, client }) {
+  return handleTeamSuspension({ command, ack, respond, client, suspend: true });
+}
+
+async function unsuspendTeamMember({ command, ack, respond, client }) {
+  return handleTeamSuspension({ command, ack, respond, client, suspend: false });
+}
+
+async function handleTeamSuspension({ command, ack, respond, client, suspend }) {
+  const action = suspend ? "Suspending" : "Reactivating";
+  const verb = suspend ? "suspended" : "reactivated";
+  const cmdName = suspend ? "/dd-team-suspend" : "/dd-team-unsuspend";
+
+  const updateResponse = await ackWithProcessing(
+    ack,
+    respond,
+    `${action} team member...`,
+    command
+  );
+
+  try {
+    const parts = command.text.trim().split(/\s+/).filter(Boolean);
+
+    if (parts.length === 0) {
+      await updateResponse({
+        blocks: createCommandErrorBlocks(
+          `Usage: \`${cmdName} @user [TeamName]\``,
+          [
+            `\`${cmdName} @john\` (uses current channel's team)`,
+            `\`${cmdName} @john Engineering\``,
+          ]
+        ),
+      });
+      return;
+    }
+
+    const targetSlackUserId = parseUserMention(parts[0]);
+    if (!targetSlackUserId) {
+      await updateResponse({
+        blocks: createCommandErrorBlocks(
+          "Invalid user mention. Please use @mention format (e.g., @john)"
+        ),
+      });
+      return;
+    }
+
+    const teamName = parts.slice(1).join(" ").trim();
+    let team;
+    if (teamName) {
+      team = await teamService.findTeamByName(teamName);
+      if (!team) {
+        await updateResponse({
+          blocks: createCommandErrorBlocks(`Team "${teamName}" not found`),
+        });
+        return;
+      }
+    } else {
+      team = await teamService.findTeamByChannel(command.channel_id);
+      if (!team) {
+        await updateResponse({
+          blocks: createCommandErrorBlocks(
+            "No team found in this channel.",
+            [
+              `Run \`${cmdName} @user [TeamName]\` to target a specific team`,
+              `Or run \`${cmdName} @user\` inside a team channel`,
+            ]
+          ),
+        });
+        return;
+      }
+    }
+
+    await teamService.setTeamMemberActive(
+      command.user_id,
+      targetSlackUserId,
+      team.id,
+      !suspend,
+      client
+    );
+
+    await updateResponse({
+      text: `✅ <@${targetSlackUserId}> has been ${verb} ${
+        suspend ? "from" : "in"
+      } team "${team.name}".`,
+    });
+  } catch (error) {
+    await updateResponse({
+      blocks: createCommandErrorBlocks(`Error: ${error.message}`),
+    });
+  }
+}
+
+async function suspendOrgMember({ command, ack, respond, client }) {
+  return handleOrgSuspension({ command, ack, respond, client, suspend: true });
+}
+
+async function unsuspendOrgMember({ command, ack, respond, client }) {
+  return handleOrgSuspension({ command, ack, respond, client, suspend: false });
+}
+
+async function handleOrgSuspension({ command, ack, respond, client, suspend }) {
+  const action = suspend ? "Suspending" : "Reactivating";
+  const verb = suspend ? "suspended" : "reactivated";
+  const cmdName = suspend ? "/dd-org-suspend" : "/dd-org-unsuspend";
+
+  const updateResponse = await ackWithProcessing(
+    ack,
+    respond,
+    `${action} organization member...`,
+    command
+  );
+
+  try {
+    const parts = command.text.trim().split(/\s+/).filter(Boolean);
+
+    if (parts.length === 0) {
+      await updateResponse({
+        blocks: createCommandErrorBlocks(
+          `Usage: \`${cmdName} @user\``,
+          [`\`${cmdName} @john\``]
+        ),
+      });
+      return;
+    }
+
+    const targetSlackUserId = parseUserMention(parts[0]);
+    if (!targetSlackUserId) {
+      await updateResponse({
+        blocks: createCommandErrorBlocks(
+          "Invalid user mention. Please use @mention format (e.g., @john)"
+        ),
+      });
+      return;
+    }
+
+    const result = await userService.setOrganizationMemberActive(
+      command.user_id,
+      targetSlackUserId,
+      !suspend,
+      client
+    );
+
+    await updateResponse({
+      text: `✅ <@${targetSlackUserId}> has been ${verb} ${
+        suspend ? "from" : "in"
+      } organization "${result.organization.name}". ${
+        result.teamMembershipsUpdated
+      } team membership(s) ${verb}.`,
+    });
+  } catch (error) {
+    await updateResponse({
+      blocks: createCommandErrorBlocks(`Error: ${error.message}`),
+    });
+  }
+}
+
 module.exports = {
   createTeam,
   joinTeam,
@@ -480,4 +643,8 @@ module.exports = {
   listTeams,
   listMembers,
   updateTeam,
+  suspendTeamMember,
+  unsuspendTeamMember,
+  suspendOrgMember,
+  unsuspendOrgMember,
 };

--- a/src/commands/team.js
+++ b/src/commands/team.js
@@ -622,12 +622,14 @@ async function handleOrgSuspension({ command, ack, respond, client, suspend }) {
       client
     );
 
+    const detail = suspend
+      ? `${result.teamMembershipsUpdated} active team membership(s) suspended.`
+      : `Use \`/dd-team-unsuspend @user [TeamName]\` to restore team memberships.`;
+
     await updateResponse({
       text: `✅ <@${targetSlackUserId}> has been ${verb} ${
         suspend ? "from" : "in"
-      } organization "${result.organization.name}". ${
-        result.teamMembershipsUpdated
-      } team membership(s) ${verb}.`,
+      } organization "${result.organization.name}". ${detail}`,
     });
   } catch (error) {
     await updateResponse({

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -1,0 +1,35 @@
+const userService = require("../services/userService");
+
+function setupEvents(app) {
+  // Slack fires `user_change` whenever a workspace user's profile changes,
+  // including when they're deactivated (event.user.deleted === true).
+  app.event("user_change", async ({ event }) => {
+    try {
+      const slackUser = event.user;
+      if (!slackUser || !slackUser.deleted) {
+        return;
+      }
+
+      const result = await userService.suspendUserSystemWide(slackUser.id);
+
+      if (!result.found) {
+        console.log(
+          `[user_change] Deactivated Slack user ${slackUser.id} not present in DB; nothing to suspend`
+        );
+        return;
+      }
+
+      console.log(
+        `[user_change] Auto-suspended deactivated Slack user ${slackUser.id}: ` +
+          `${result.orgMembershipsSuspended} org membership(s), ` +
+          `${result.teamMembershipsSuspended} team membership(s)`
+      );
+    } catch (error) {
+      console.error("[user_change] Failed to auto-suspend user", error);
+    }
+  });
+
+  console.log("✅ Events registered");
+}
+
+module.exports = { setupEvents };

--- a/src/services/teamService.js
+++ b/src/services/teamService.js
@@ -458,7 +458,7 @@ class TeamService {
 
     if (!isTeamAdmin && !isOrgManager) {
       throw new Error(
-        "You need team admin or organization owner permissions for this action"
+        "You need team admin or organization owner/admin permissions for this action"
       );
     }
 
@@ -471,7 +471,7 @@ class TeamService {
     }
 
     if (targetUser.id === adminUser.id) {
-      throw new Error("You cannot suspend yourself");
+      throw new Error("You cannot change your own team membership status");
     }
 
     const targetMembership = await prisma.teamMember.findUnique({
@@ -482,6 +482,33 @@ class TeamService {
 
     if (!targetMembership) {
       throw new Error("Target user is not a member of this team");
+    }
+
+    const targetOrgMembership = await prisma.organizationMember.findUnique({
+      where: {
+        organizationId_userId: {
+          organizationId: team.organizationId,
+          userId: targetUser.id,
+        },
+      },
+    });
+
+    // Block reactivating a team membership when the user is org-suspended
+    if (isActive && targetOrgMembership && !targetOrgMembership.isActive) {
+      throw new Error(
+        "This member is suspended from the organization. Use /dd-org-unsuspend first."
+      );
+    }
+
+    // Only org owners can change an org owner's team membership
+    if (
+      targetOrgMembership &&
+      targetOrgMembership.role === "OWNER" &&
+      (!orgMembership || orgMembership.role !== "OWNER")
+    ) {
+      throw new Error(
+        "Only organization owners can change an organization owner's team membership"
+      );
     }
 
     if (targetMembership.isActive === isActive) {

--- a/src/services/teamService.js
+++ b/src/services/teamService.js
@@ -414,6 +414,109 @@ class TeamService {
     return membership && membership.role === "ADMIN";
   }
 
+  async setTeamMemberActive(adminSlackUserId, targetSlackUserId, teamId, isActive, slackClient = null) {
+    const adminUserData = await userService.fetchSlackUserData(
+      adminSlackUserId,
+      slackClient
+    );
+    const adminUser = await userService.findOrCreateUser(
+      adminSlackUserId,
+      adminUserData
+    );
+
+    const team = await prisma.team.findUnique({
+      where: { id: teamId },
+      include: { organization: true },
+    });
+
+    if (!team) {
+      throw new Error("Team not found");
+    }
+
+    // Permission: team admin or org owner/admin
+    const adminMembership = await prisma.teamMember.findUnique({
+      where: {
+        teamId_userId: { teamId, userId: adminUser.id },
+      },
+    });
+
+    const orgMembership = await prisma.organizationMember.findUnique({
+      where: {
+        organizationId_userId: {
+          organizationId: team.organizationId,
+          userId: adminUser.id,
+        },
+      },
+    });
+
+    const isTeamAdmin =
+      adminMembership && adminMembership.isActive && adminMembership.role === "ADMIN";
+    const isOrgManager =
+      orgMembership &&
+      orgMembership.isActive &&
+      ["OWNER", "ADMIN"].includes(orgMembership.role);
+
+    if (!isTeamAdmin && !isOrgManager) {
+      throw new Error(
+        "You need team admin or organization owner permissions for this action"
+      );
+    }
+
+    const targetUser = await prisma.user.findUnique({
+      where: { slackUserId: targetSlackUserId },
+    });
+
+    if (!targetUser) {
+      throw new Error("Target user not found");
+    }
+
+    if (targetUser.id === adminUser.id) {
+      throw new Error("You cannot suspend yourself");
+    }
+
+    const targetMembership = await prisma.teamMember.findUnique({
+      where: {
+        teamId_userId: { teamId, userId: targetUser.id },
+      },
+    });
+
+    if (!targetMembership) {
+      throw new Error("Target user is not a member of this team");
+    }
+
+    if (targetMembership.isActive === isActive) {
+      throw new Error(
+        isActive
+          ? "Member is already active in this team"
+          : "Member is already suspended from this team"
+      );
+    }
+
+    // Prevent removing the only active admin
+    if (!isActive && targetMembership.role === "ADMIN") {
+      const otherActiveAdmins = await prisma.teamMember.count({
+        where: {
+          teamId,
+          role: "ADMIN",
+          isActive: true,
+          userId: { not: targetUser.id },
+        },
+      });
+      if (otherActiveAdmins === 0) {
+        throw new Error(
+          "Cannot suspend the only active admin of this team. Promote another admin first."
+        );
+      }
+    }
+
+    return await prisma.teamMember.update({
+      where: {
+        teamId_userId: { teamId, userId: targetUser.id },
+      },
+      data: { isActive },
+    });
+  }
+
   async getUserTeams(slackUserId, slackClient = null) {
     const userData = await userService.fetchSlackUserData(slackUserId, slackClient);
     const user = await userService.findOrCreateUser(slackUserId, userData);

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -297,42 +297,48 @@ class UserService {
     }
 
     const orgTeams = await prisma.team.findMany({
-      where: { organizationId: adminOrg.id },
+      where: { organizationId: adminOrg.id, isActive: true },
       select: { id: true },
     });
     const teamIds = orgTeams.map((t) => t.id);
 
     if (!isActive) {
-      // Pre-check: suspending this user must not leave any team without an active admin
-      const adminMemberships = await prisma.teamMember.findMany({
+      // Pre-check: suspending this user must not leave any team without an active admin.
+      // Single aggregate query — count active admins per team where the target is an
+      // admin, then filter to teams with exactly one (which must be the target).
+      const adminTeams = await prisma.teamMember.findMany({
         where: {
           userId: targetUser.id,
           isActive: true,
           role: "ADMIN",
           teamId: { in: teamIds },
         },
-        include: { team: { select: { name: true } } },
+        select: { teamId: true, team: { select: { name: true } } },
       });
 
-      const orphanedTeams = [];
-      for (const m of adminMemberships) {
-        const otherActiveAdmins = await prisma.teamMember.count({
+      if (adminTeams.length > 0) {
+        const adminCounts = await prisma.teamMember.groupBy({
+          by: ["teamId"],
           where: {
-            teamId: m.teamId,
+            teamId: { in: adminTeams.map((m) => m.teamId) },
             role: "ADMIN",
             isActive: true,
-            userId: { not: targetUser.id },
           },
+          _count: { _all: true },
         });
-        if (otherActiveAdmins === 0) {
-          orphanedTeams.push(m.team.name);
-        }
-      }
 
-      if (orphanedTeams.length > 0) {
-        throw new Error(
-          `Cannot suspend this member — they are the only active admin of: ${orphanedTeams.join(", ")}. Promote another admin in those teams first.`
+        const countByTeam = new Map(
+          adminCounts.map((c) => [c.teamId, c._count._all])
         );
+        const orphanedTeams = adminTeams
+          .filter((m) => (countByTeam.get(m.teamId) || 0) <= 1)
+          .map((m) => m.team.name);
+
+        if (orphanedTeams.length > 0) {
+          throw new Error(
+            `Cannot suspend this member — they are the only active admin of: ${orphanedTeams.join(", ")}. Promote another admin in those teams first.`
+          );
+        }
       }
     }
 

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -230,6 +230,105 @@ class UserService {
     });
   }
 
+  async setOrganizationMemberActive(adminSlackUserId, targetSlackUserId, isActive, slackClient = null) {
+    const adminUserData = await this.fetchSlackUserData(adminSlackUserId, slackClient);
+    const adminUser = await this.findOrCreateUser(adminSlackUserId, adminUserData);
+
+    const adminOrg = await this.getUserOrganization(adminSlackUserId);
+    if (!adminOrg) {
+      throw new Error("You must belong to an organization to manage members");
+    }
+
+    const adminOrgMembership = await prisma.organizationMember.findUnique({
+      where: {
+        organizationId_userId: {
+          organizationId: adminOrg.id,
+          userId: adminUser.id,
+        },
+      },
+    });
+
+    if (
+      !adminOrgMembership ||
+      !adminOrgMembership.isActive ||
+      !["OWNER", "ADMIN"].includes(adminOrgMembership.role)
+    ) {
+      throw new Error(
+        "You need organization owner or admin permissions for this action"
+      );
+    }
+
+    const targetUser = await prisma.user.findUnique({
+      where: { slackUserId: targetSlackUserId },
+    });
+
+    if (!targetUser) {
+      throw new Error("Target user not found");
+    }
+
+    if (targetUser.id === adminUser.id) {
+      throw new Error("You cannot suspend yourself");
+    }
+
+    const targetOrgMembership = await prisma.organizationMember.findUnique({
+      where: {
+        organizationId_userId: {
+          organizationId: adminOrg.id,
+          userId: targetUser.id,
+        },
+      },
+    });
+
+    if (!targetOrgMembership) {
+      throw new Error("Target user is not a member of your organization");
+    }
+
+    // Owners can only be suspended by other owners
+    if (targetOrgMembership.role === "OWNER" && adminOrgMembership.role !== "OWNER") {
+      throw new Error("Only organization owners can suspend another owner");
+    }
+
+    if (targetOrgMembership.isActive === isActive) {
+      throw new Error(
+        isActive
+          ? "Member is already active in this organization"
+          : "Member is already suspended from this organization"
+      );
+    }
+
+    // Cascade: update org membership and all team memberships in this org
+    const orgTeams = await prisma.team.findMany({
+      where: { organizationId: adminOrg.id },
+      select: { id: true },
+    });
+    const teamIds = orgTeams.map((t) => t.id);
+
+    const [orgUpdate, teamUpdate] = await prisma.$transaction([
+      prisma.organizationMember.update({
+        where: {
+          organizationId_userId: {
+            organizationId: adminOrg.id,
+            userId: targetUser.id,
+          },
+        },
+        data: { isActive },
+      }),
+      prisma.teamMember.updateMany({
+        where: {
+          userId: targetUser.id,
+          teamId: { in: teamIds },
+        },
+        data: { isActive },
+      }),
+    ]);
+
+    return {
+      organizationMember: orgUpdate,
+      teamMembershipsUpdated: teamUpdate.count,
+      organization: adminOrg,
+    };
+  }
+
   async setMemberLeave(targetSlackUserId, startDate, endDate, reason, slackClient = null) {
     const userData = await this.fetchSlackUserData(targetSlackUserId, slackClient);
     const user = await this.findOrCreateUser(targetSlackUserId, userData);

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -267,7 +267,7 @@ class UserService {
     }
 
     if (targetUser.id === adminUser.id) {
-      throw new Error("You cannot suspend yourself");
+      throw new Error("You cannot change your own organization membership status");
     }
 
     const targetOrgMembership = await prisma.organizationMember.findUnique({
@@ -283,9 +283,9 @@ class UserService {
       throw new Error("Target user is not a member of your organization");
     }
 
-    // Owners can only be suspended by other owners
+    // Owner status can only be changed by another owner
     if (targetOrgMembership.role === "OWNER" && adminOrgMembership.role !== "OWNER") {
-      throw new Error("Only organization owners can suspend another owner");
+      throw new Error("Only organization owners can change another owner's status");
     }
 
     if (targetOrgMembership.isActive === isActive) {
@@ -296,14 +296,51 @@ class UserService {
       );
     }
 
-    // Cascade: update org membership and all team memberships in this org
     const orgTeams = await prisma.team.findMany({
       where: { organizationId: adminOrg.id },
       select: { id: true },
     });
     const teamIds = orgTeams.map((t) => t.id);
 
-    const [orgUpdate, teamUpdate] = await prisma.$transaction([
+    if (!isActive) {
+      // Pre-check: suspending this user must not leave any team without an active admin
+      const adminMemberships = await prisma.teamMember.findMany({
+        where: {
+          userId: targetUser.id,
+          isActive: true,
+          role: "ADMIN",
+          teamId: { in: teamIds },
+        },
+        include: { team: { select: { name: true } } },
+      });
+
+      const orphanedTeams = [];
+      for (const m of adminMemberships) {
+        const otherActiveAdmins = await prisma.teamMember.count({
+          where: {
+            teamId: m.teamId,
+            role: "ADMIN",
+            isActive: true,
+            userId: { not: targetUser.id },
+          },
+        });
+        if (otherActiveAdmins === 0) {
+          orphanedTeams.push(m.team.name);
+        }
+      }
+
+      if (orphanedTeams.length > 0) {
+        throw new Error(
+          `Cannot suspend this member — they are the only active admin of: ${orphanedTeams.join(", ")}. Promote another admin in those teams first.`
+        );
+      }
+    }
+
+    // On suspend: deactivate all currently-active team memberships in this org.
+    // On unsuspend: reactivate the org membership only — do NOT resurrect team
+    // memberships that were left or team-suspended independently. Admin can
+    // use /dd-team-unsuspend per team to restore those.
+    const ops = [
       prisma.organizationMember.update({
         where: {
           organizationId_userId: {
@@ -313,19 +350,30 @@ class UserService {
         },
         data: { isActive },
       }),
-      prisma.teamMember.updateMany({
-        where: {
-          userId: targetUser.id,
-          teamId: { in: teamIds },
-        },
-        data: { isActive },
-      }),
-    ]);
+    ];
+
+    if (!isActive) {
+      ops.push(
+        prisma.teamMember.updateMany({
+          where: {
+            userId: targetUser.id,
+            teamId: { in: teamIds },
+            isActive: true,
+          },
+          data: { isActive: false },
+        })
+      );
+    }
+
+    const results = await prisma.$transaction(ops);
+    const orgUpdate = results[0];
+    const teamMembershipsUpdated = isActive ? 0 : results[1].count;
 
     return {
       organizationMember: orgUpdate,
-      teamMembershipsUpdated: teamUpdate.count,
+      teamMembershipsUpdated,
       organization: adminOrg,
+      cascadedTeams: !isActive,
     };
   }
 

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -377,6 +377,38 @@ class UserService {
     };
   }
 
+  // System-triggered suspension across every org/team the user belongs to.
+  // Used when Slack reports the workspace user as deactivated. Bypasses
+  // admin permission and sole-admin guards (the user no longer exists in
+  // Slack, so the team needs the suspension applied regardless).
+  async suspendUserSystemWide(slackUserId) {
+    const user = await prisma.user.findUnique({
+      where: { slackUserId },
+    });
+
+    if (!user) {
+      return { found: false };
+    }
+
+    const [orgUpdate, teamUpdate] = await prisma.$transaction([
+      prisma.organizationMember.updateMany({
+        where: { userId: user.id, isActive: true },
+        data: { isActive: false },
+      }),
+      prisma.teamMember.updateMany({
+        where: { userId: user.id, isActive: true },
+        data: { isActive: false },
+      }),
+    ]);
+
+    return {
+      found: true,
+      userId: user.id,
+      orgMembershipsSuspended: orgUpdate.count,
+      teamMembershipsSuspended: teamUpdate.count,
+    };
+  }
+
   async setMemberLeave(targetSlackUserId, startDate, endDate, reason, slackClient = null) {
     const userData = await this.fetchSlackUserData(targetSlackUserId, slackClient);
     const user = await this.findOrCreateUser(targetSlackUserId, userData);

--- a/web/src/data/changelog.json
+++ b/web/src/data/changelog.json
@@ -1,9 +1,27 @@
 {
   "versions": [
     {
+      "version": "1.6.0",
+      "date": "2026-05-17",
+      "isLatest": true,
+      "changes": [
+        {
+          "type": "added",
+          "title": "Suspend Inactive Members",
+          "items": [
+            "Team admins can now suspend a member from a single team with `/dd-team-suspend @user [team-name]` (and reactivate with `/dd-team-unsuspend`)",
+            "Organization owners and admins can suspend a member across the entire organization with `/dd-org-suspend @user` (reactivate with `/dd-org-unsuspend`)",
+            "Suspended members stop receiving standup reminders and are excluded from posted summaries",
+            "Daily Dose now automatically suspends members when they're deactivated in Slack — no manual cleanup needed",
+            "Safety guards prevent suspending the only active admin of a team or accidentally changing an organization owner's status"
+          ]
+        }
+      ]
+    },
+    {
       "version": "1.5.1",
       "date": "2026-04-30",
-      "isLatest": true,
+      "isLatest": false,
       "changes": [
         {
           "type": "fixed",

--- a/web/src/data/changelog.json
+++ b/web/src/data/changelog.json
@@ -11,7 +11,7 @@
           "items": [
             "Team admins can now suspend a member from a single team with `/dd-team-suspend @user [team-name]` (and reactivate with `/dd-team-unsuspend`)",
             "Organization owners and admins can suspend a member across the entire organization with `/dd-org-suspend @user` (reactivate with `/dd-org-unsuspend`)",
-            "Suspended members stop receiving standup reminders and are excluded from posted summaries",
+            "Suspended members cannot submit standups, stop receiving reminders, and are excluded from posted summaries",
             "Daily Dose now automatically suspends members when they're deactivated in Slack — no manual cleanup needed",
             "Safety guards prevent suspending the only active admin of a team or accidentally changing an organization owner's status"
           ]

--- a/web/src/data/docs.json
+++ b/web/src/data/docs.json
@@ -280,6 +280,45 @@
                 "# Change team name\n/dd-team-update Engineering name=\"Engineering Team\"",
                 "# Disable admin notifications\n/dd-team-update Engineering notifications=false"
               ]
+            },
+            {
+              "type": "command",
+              "command": "/dd-team-suspend @user [team-name]",
+              "description": "Suspend a member from a team (team admin or org owner/admin). Suspended members stop receiving reminders, are excluded from standup posts, and cannot submit standups for that team. Blocked when the user is the only active admin of the team.",
+              "examples": [
+                "# Suspend from team in current channel\n/dd-team-suspend @john",
+                "# Suspend from a specific team\n/dd-team-suspend @john Engineering"
+              ]
+            },
+            {
+              "type": "command",
+              "command": "/dd-team-unsuspend @user [team-name]",
+              "description": "Reactivate a suspended team member (team admin or org owner/admin). Blocked if the user is currently org-suspended — run /dd-org-unsuspend first.",
+              "examples": [
+                "# Reactivate in team for current channel\n/dd-team-unsuspend @john",
+                "# Reactivate in specific team\n/dd-team-unsuspend @john Engineering"
+              ]
+            },
+            {
+              "type": "command",
+              "command": "/dd-org-suspend @user",
+              "description": "Suspend a member across the entire organization (org owner/admin only). Cascades the suspension to every active team membership in the organization. Blocked if the user is the only active admin of any team — promote another admin first.",
+              "examples": [
+                "/dd-org-suspend @john"
+              ]
+            },
+            {
+              "type": "command",
+              "command": "/dd-org-unsuspend @user",
+              "description": "Reactivate a suspended organization member (org owner/admin only). Restores org membership only — does NOT resurrect team memberships. Use /dd-team-unsuspend per team to restore team access.",
+              "examples": [
+                "/dd-org-unsuspend @john"
+              ]
+            },
+            {
+              "type": "note",
+              "title": "Automatic Slack Deactivation",
+              "value": "When a member is deactivated in Slack, Daily Dose automatically suspends them across every organization and team they belonged to. No admin action required."
             }
           ]
         },


### PR DESCRIPTION
## Summary

Adds member suspension/deactivation for teams and organizations.

- **Team-level** (team admin or org owner/admin): `/dd-team-suspend @user [TeamName]` and `/dd-team-unsuspend @user [TeamName]`
- **Org-wide** (org owner/admin only): `/dd-org-suspend @user` and `/dd-org-unsuspend @user` — cascades to every team membership in the org

Suspension toggles the existing `isActive` flag on `TeamMember` / `OrganizationMember` — no schema change. Suspended users stop receiving reminders, are excluded from standup posts, and cannot submit standups for those teams (all existing flows already filter by `isActive: true`).

Guards:
- Cannot suspend yourself
- Cannot suspend the only active admin of a team
- Non-owners cannot suspend an owner
- Org-level cascade wrapped in a Prisma transaction

## Test plan

- [ ] Team admin runs `/dd-team-suspend @member` in a team channel — suspended user no longer receives reminders or appears in posts
- [ ] `/dd-team-unsuspend @member` restores reminders and inclusion in posts
- [ ] Non-admin gets a permission error
- [ ] Suspending the only active admin is blocked
- [ ] Org owner runs `/dd-org-suspend @member` — user is suspended across all teams
- [ ] `/dd-org-unsuspend @member` reactivates org + team memberships
- [ ] Non-owner cannot suspend an owner
- [ ] Self-suspension is blocked

https://claude.ai/code/session_01ENgdC9nZehE1ZAUXoLMgSn

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENgdC9nZehE1ZAUXoLMgSn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Four Slack slash commands to suspend/unsuspend members at team or org scope; team commands default to the current channel if no team specified
  * Automatic system-wide suspension when a Slack workspace user is deactivated; app now listens for relevant Slack events

* **Documentation**
  * Updated quick-start and team management docs and changelog to document commands, behavior, and safety safeguards (self/critical-admin protection)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jnahian/daily-dose/pull/10?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->