### PR TITLE
Add /dd-org-promote command (org owner/admin only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Service layer: added `userService.promoteOrganizationMember()` and `teamService.promoteTeamMember()`
   - Accepts the same three target formats as the suspend commands (mention, raw Slack user ID, bare `@username`/`username`) via the existing `resolveTargetSlackUserId` helper
   - Command registered without `stripFormatting` so `<@U…|name>` mention tokens survive for `parseUserMention`
+  - Team-scope lookup is scoped to the actor's organization to prevent cross-tenant collisions when a team of the same name exists in another org
   - Slash command added to `slack-app-manifest.json`
+
+### Changed
+
+- `teamService.findTeamByName(teamName, organizationId = null)` now accepts an optional `organizationId` filter; existing call sites that omit it retain the previous global behavior
 
 ## [1.6.1] - 2026-05-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `/dd-org-promote @user [TeamName]` — promotes a user to admin role (org owner/admin only)
+  - With no `TeamName`: promotes the target's `OrganizationMember.role` from `MEMBER` to `ADMIN` in the actor's organization
+  - With a `TeamName`: promotes the target's `TeamMember.role` from `MEMBER` to `ADMIN` in that team
+  - Permission gate: actor must have an active `OrganizationMember` with role `OWNER` or `ADMIN`; team-scope path checks the team's org, not the channel
+  - Guards: target must be an active member of the relevant scope (org or team); rejects self-promotion, already-admin targets, and org owners (already at the highest role)
+  - Service layer: added `userService.promoteOrganizationMember()` and `teamService.promoteTeamMember()`
+  - Accepts the same three target formats as the suspend commands (mention, raw Slack user ID, bare `@username`/`username`) via the existing `resolveTargetSlackUserId` helper
+  - Command registered without `stripFormatting` so `<@U…|name>` mention tokens survive for `parseUserMention`
+  - Slash command added to `slack-app-manifest.json`
+
 ## [1.6.1] - 2026-05-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ When you first interact with the bot, you'll be automatically added to your orga
 /dd-team-unsuspend @user [TeamName]   # Reactivate a suspended team member ⚠️ (admin only)
 /dd-org-suspend @user                 # Suspend member from entire organization ⚠️ (org owner/admin)
 /dd-org-unsuspend @user               # Reactivate suspended org member ⚠️ (org owner/admin)
+/dd-org-promote @user                 # Promote to organization admin ⚠️ (org owner/admin)
+/dd-org-promote @user Engineering     # Promote to team admin in a specific team ⚠️ (org owner/admin)
 ```
 
 ### 3. Submit Your Daily Standup
@@ -384,6 +386,11 @@ These commands allow team admins and organization owners to manually trigger sta
   - Blocked if the user is the only active admin of any team in the org
 - `/dd-org-unsuspend @user` - Reactivate a suspended organization member ⚠️ **(org owner/admin only)**
   - Restores org membership only; use `/dd-team-unsuspend` to re-add the user to specific teams
+- `/dd-org-promote @user [team-name]` - Promote a user to admin role ⚠️ **(org owner/admin only)**
+  - **Org scope**: `/dd-org-promote @john` (promotes to organization admin)
+  - **Team scope**: `/dd-org-promote @john Engineering` (promotes to team admin in a specific team)
+  - Target must already be an active member of the relevant scope
+  - Cannot promote yourself or an existing admin/owner
 
 ### 🌴 Leave Management
 

--- a/slack-app-manifest.json
+++ b/slack-app-manifest.json
@@ -81,6 +81,13 @@
                 "should_escape": false
             },
             {
+                "command": "/dd-org-promote",
+                "url": "{{APP_URL}}/slack/events",
+                "description": "Promote a user to organization admin, or team admin if a team is specified (org owner/admin only)",
+                "usage_hint": "@user [TeamName]",
+                "should_escape": false
+            },
+            {
                 "command": "/dd-leave-set",
                 "url": "{{APP_URL}}/slack/events",
                 "description": "Set leave dates to skip standup reminders",

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -30,6 +30,7 @@ function setupCommands(app) {
   app.command("/dd-team-unsuspend", teamCommands.unsuspendTeamMember);
   app.command("/dd-org-suspend", teamCommands.suspendOrgMember);
   app.command("/dd-org-unsuspend", teamCommands.unsuspendOrgMember);
+  app.command("/dd-org-promote", teamCommands.promoteOrgMember);
 
   // Leave management commands - wrapped with formatting removal middleware
   app.command("/dd-leave-list", stripFormatting(), leaveCommands.listLeaves);

--- a/src/commands/team.js
+++ b/src/commands/team.js
@@ -690,6 +690,89 @@ async function handleOrgSuspension({ command, ack, respond, client, suspend }) {
   }
 }
 
+async function promoteOrgMember({ command, ack, respond, client }) {
+  const updateResponse = await ackWithProcessing(
+    ack,
+    respond,
+    "Promoting member...",
+    command
+  );
+
+  try {
+    const parts = command.text.trim().split(/\s+/).filter(Boolean);
+
+    if (parts.length === 0) {
+      await updateResponse({
+        blocks: createCommandErrorBlocks(
+          "Usage: `/dd-org-promote @user [TeamName]`",
+          [
+            "`/dd-org-promote @john` — promote to organization admin",
+            "`/dd-org-promote @john Engineering` — promote to team admin in Engineering",
+          ]
+        ),
+      });
+      return;
+    }
+
+    const teamName = parts.slice(1).join(" ").trim();
+    const adminOrg = await userService.getUserOrganization(command.user_id);
+
+    const targetSlackUserId = await resolveTargetSlackUserId(
+      parts[0],
+      adminOrg ? adminOrg.id : null
+    );
+    if (!targetSlackUserId) {
+      await updateResponse({
+        blocks: createCommandErrorBlocks(
+          "Could not resolve target user.",
+          [
+            "Use `@user` mention (e.g., `@john`)",
+            "Or pass the Slack user ID directly (e.g., `U0123ABCD`)",
+            "Or pass the username (e.g., `@john` or `john`)",
+          ]
+        ),
+      });
+      return;
+    }
+
+    if (teamName) {
+      const team = await teamService.findTeamByName(teamName);
+      if (!team) {
+        await updateResponse({
+          blocks: createCommandErrorBlocks(`Team "${teamName}" not found`),
+        });
+        return;
+      }
+
+      const result = await teamService.promoteTeamMember(
+        command.user_id,
+        targetSlackUserId,
+        team.id,
+        client
+      );
+
+      await updateResponse({
+        text: `✅ <@${targetSlackUserId}> has been promoted to team admin in "${result.team.name}".`,
+      });
+      return;
+    }
+
+    const result = await userService.promoteOrganizationMember(
+      command.user_id,
+      targetSlackUserId,
+      client
+    );
+
+    await updateResponse({
+      text: `✅ <@${targetSlackUserId}> has been promoted to organization admin in "${result.organization.name}".`,
+    });
+  } catch (error) {
+    await updateResponse({
+      blocks: createCommandErrorBlocks(`Error: ${error.message}`),
+    });
+  }
+}
+
 module.exports = {
   createTeam,
   joinTeam,
@@ -701,4 +784,5 @@ module.exports = {
   unsuspendTeamMember,
   suspendOrgMember,
   unsuspendOrgMember,
+  promoteOrgMember,
 };

--- a/src/commands/team.js
+++ b/src/commands/team.js
@@ -717,6 +717,15 @@ async function promoteOrgMember({ command, ack, respond, client }) {
     const teamName = parts.slice(1).join(" ").trim();
     const adminOrg = await userService.getUserOrganization(command.user_id);
 
+    if (teamName && !adminOrg) {
+      await updateResponse({
+        blocks: createCommandErrorBlocks(
+          "You must belong to an organization to promote a team member."
+        ),
+      });
+      return;
+    }
+
     const targetSlackUserId = await resolveTargetSlackUserId(
       parts[0],
       adminOrg ? adminOrg.id : null
@@ -736,10 +745,12 @@ async function promoteOrgMember({ command, ack, respond, client }) {
     }
 
     if (teamName) {
-      const team = await teamService.findTeamByName(teamName);
+      const team = await teamService.findTeamByName(teamName, adminOrg.id);
       if (!team) {
         await updateResponse({
-          blocks: createCommandErrorBlocks(`Team "${teamName}" not found`),
+          blocks: createCommandErrorBlocks(
+            `Team "${teamName}" not found in your organization`
+          ),
         });
         return;
       }

--- a/src/services/teamService.js
+++ b/src/services/teamService.js
@@ -593,6 +593,85 @@ class TeamService {
     });
   }
 
+  async promoteTeamMember(adminSlackUserId, targetSlackUserId, teamId, slackClient = null) {
+    const adminUserData = await userService.fetchSlackUserData(
+      adminSlackUserId,
+      slackClient
+    );
+    const adminUser = await userService.findOrCreateUser(
+      adminSlackUserId,
+      adminUserData
+    );
+
+    const team = await prisma.team.findUnique({
+      where: { id: teamId },
+      include: { organization: true },
+    });
+
+    if (!team) {
+      throw new Error("Team not found");
+    }
+
+    // Permission: org owner or org admin only (per /dd-org-promote requirements)
+    const orgMembership = await prisma.organizationMember.findUnique({
+      where: {
+        organizationId_userId: {
+          organizationId: team.organizationId,
+          userId: adminUser.id,
+        },
+      },
+    });
+
+    if (
+      !orgMembership ||
+      !orgMembership.isActive ||
+      !["OWNER", "ADMIN"].includes(orgMembership.role)
+    ) {
+      throw new Error(
+        "You need organization owner or admin permissions for this action"
+      );
+    }
+
+    const targetUser = await prisma.user.findUnique({
+      where: { slackUserId: targetSlackUserId },
+    });
+
+    if (!targetUser) {
+      throw new Error("Target user not found");
+    }
+
+    if (targetUser.id === adminUser.id) {
+      throw new Error("You cannot promote yourself");
+    }
+
+    const targetMembership = await prisma.teamMember.findUnique({
+      where: {
+        teamId_userId: { teamId, userId: targetUser.id },
+      },
+    });
+
+    if (!targetMembership || !targetMembership.isActive) {
+      throw new Error("Target user is not an active member of this team");
+    }
+
+    if (targetMembership.role === "ADMIN") {
+      throw new Error("Target user is already a team admin");
+    }
+
+    const updated = await prisma.teamMember.update({
+      where: {
+        teamId_userId: { teamId, userId: targetUser.id },
+      },
+      data: { role: "ADMIN" },
+    });
+
+    return {
+      teamMember: updated,
+      team,
+      previousRole: targetMembership.role,
+    };
+  }
+
   async getUserTeams(slackUserId, slackClient = null) {
     const userData = await userService.fetchSlackUserData(slackUserId, slackClient);
     const user = await userService.findOrCreateUser(slackUserId, userData);

--- a/src/services/teamService.js
+++ b/src/services/teamService.js
@@ -308,7 +308,7 @@ class TeamService {
     });
   }
 
-  async findTeamByName(teamName) {
+  async findTeamByName(teamName, organizationId = null) {
     return await prisma.team.findFirst({
       where: {
         name: {
@@ -316,6 +316,7 @@ class TeamService {
           mode: "insensitive",
         },
         isActive: true,
+        ...(organizationId ? { organizationId } : {}),
       },
       include: {
         organization: true,

--- a/src/services/teamService.js
+++ b/src/services/teamService.js
@@ -654,6 +654,21 @@ class TeamService {
       throw new Error("Target user is not an active member of this team");
     }
 
+    const targetOrgMembership = await prisma.organizationMember.findUnique({
+      where: {
+        organizationId_userId: {
+          organizationId: team.organizationId,
+          userId: targetUser.id,
+        },
+      },
+    });
+
+    if (targetOrgMembership?.role === "OWNER") {
+      throw new Error(
+        "Target user is the organization owner and cannot be promoted further"
+      );
+    }
+
     if (targetMembership.role === "ADMIN") {
       throw new Error("Target user is already a team admin");
     }

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -246,6 +246,84 @@ class UserService {
     });
   }
 
+  async promoteOrganizationMember(adminSlackUserId, targetSlackUserId, slackClient = null) {
+    const adminUserData = await this.fetchSlackUserData(adminSlackUserId, slackClient);
+    const adminUser = await this.findOrCreateUser(adminSlackUserId, adminUserData);
+
+    const adminOrg = await this.getUserOrganization(adminSlackUserId);
+    if (!adminOrg) {
+      throw new Error("You must belong to an organization to manage members");
+    }
+
+    const adminOrgMembership = await prisma.organizationMember.findUnique({
+      where: {
+        organizationId_userId: {
+          organizationId: adminOrg.id,
+          userId: adminUser.id,
+        },
+      },
+    });
+
+    if (
+      !adminOrgMembership ||
+      !adminOrgMembership.isActive ||
+      !["OWNER", "ADMIN"].includes(adminOrgMembership.role)
+    ) {
+      throw new Error(
+        "You need organization owner or admin permissions for this action"
+      );
+    }
+
+    const targetUser = await prisma.user.findUnique({
+      where: { slackUserId: targetSlackUserId },
+    });
+
+    if (!targetUser) {
+      throw new Error("Target user not found");
+    }
+
+    if (targetUser.id === adminUser.id) {
+      throw new Error("You cannot promote yourself");
+    }
+
+    const targetOrgMembership = await prisma.organizationMember.findUnique({
+      where: {
+        organizationId_userId: {
+          organizationId: adminOrg.id,
+          userId: targetUser.id,
+        },
+      },
+    });
+
+    if (!targetOrgMembership || !targetOrgMembership.isActive) {
+      throw new Error("Target user is not an active member of your organization");
+    }
+
+    if (targetOrgMembership.role === "OWNER") {
+      throw new Error("Target user is the organization owner and cannot be promoted further");
+    }
+
+    if (targetOrgMembership.role === "ADMIN") {
+      throw new Error("Target user is already an organization admin");
+    }
+
+    const updated = await prisma.organizationMember.update({
+      where: {
+        organizationId_userId: {
+          organizationId: adminOrg.id,
+          userId: targetUser.id,
+        },
+      },
+      data: { role: "ADMIN" },
+    });
+
+    return {
+      organizationMember: updated,
+      organization: adminOrg,
+      previousRole: targetOrgMembership.role,
+    };
+  }
+
   async setOrganizationMemberActive(adminSlackUserId, targetSlackUserId, isActive, slackClient = null) {
     const adminUserData = await this.fetchSlackUserData(adminSlackUserId, slackClient);
     const adminUser = await this.findOrCreateUser(adminSlackUserId, adminUserData);


### PR DESCRIPTION
## Summary

- Adds `/dd-org-promote @user [TeamName]` — without `TeamName`, promotes the target to **organization admin**; with `TeamName`, promotes them to **team admin** in that team.
- Permission gated to active org `OWNER` or `ADMIN` (for both scopes).
- Reuses the existing `resolveTargetSlackUserId` helper, so mentions, raw Slack user IDs, and bare `@username`/`username` all work — same as the suspend commands. Registered without `stripFormatting` so the `<@U…|name>` mention token survives.
- Guards: rejects self-promotion, already-admin targets, org owners (already at the highest role), and inactive memberships.
- New service methods: `userService.promoteOrganizationMember()` and `teamService.promoteTeamMember()`.
- Updated `slack-app-manifest.json`, `README.md`, and `CHANGELOG.md`.

## Test plan

- [ ] Run `npm run manifest:update` to push the new slash command to Slack.
- [ ] As an org admin, `/dd-org-promote @member` — confirm target's `OrganizationMember.role` becomes `ADMIN`.
- [ ] As an org admin, `/dd-org-promote @member SomeTeam` — confirm target's `TeamMember.role` becomes `ADMIN` in that team.
- [ ] As a non-admin org member, `/dd-org-promote @member` — confirm permission error.
- [ ] `/dd-org-promote @already_admin` — confirm "already an admin" error.
- [ ] `/dd-org-promote @yourself` — confirm self-promotion error.
- [ ] `/dd-org-promote @member NonExistentTeam` — confirm team-not-found error.
- [ ] `/dd-org-promote @non_member SomeTeam` — confirm "not an active member of this team" error.

https://claude.ai/code/session_01LWagKtdbYZSZebpXGvHHJS

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWagKtdbYZSZebpXGvHHJS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/dd-org-promote `@user` [TeamName]` slash command to promote users to org or team admin. Accepts mentions, raw IDs, or bare usernames; preserves mention parsing. Prevents self-promotion and promoting existing owners/admins; shows helpful errors for invalid targets or teams.

* **Documentation**
  * Updated CHANGELOG, README and app manifest with command usage, scopes, and examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jnahian/daily-dose/pull/11?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->