### PR TITLE
perf: batch standup query lookups + add (team_id, standup_date) index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `UserFacingError` class and `sanitizeError(err, fallback?)` helper in `src/utils/errorHelper.js`. Command handlers now emit a generic `Something went wrong (ref: ...)` message for unknown errors; service-provided messages are only rendered verbatim when the service throws `UserFacingError`.
 - `parseTimeString(input)` validator and `TimeFormatError` in `src/utils/timeHelper.js`. Rejects malformed `HH:MM` input at command boundaries before scheduler registration.
 - Jest test harness at the repo root (`jest.config.js`, `npm test`, `npm run test:watch`, `npm run test:coverage`). 32 tests across `timeHelper`, `errorHelper`, and `basicAuth` middleware.
+- Composite database index `@@index([teamId, standupDate])` on `StandupResponse` (migration `20260520044120_standup_response_team_date_index`). The existing `@@unique([teamId, userId, standupDate])` constraint cannot serve team + date-range queries without a `userId`, the shape used by `getTeamResponses`, `getLateResponses`, and the response counting in `postTeamStandup`.
+- `isWorkingDayPure({ date, workDays, holidayDateSet })`, `getHolidayDateSet()`, and `getOrgDefaultWorkDays()` in `src/utils/dateHelper.js` — a pure work-day check plus batch holiday lookup for hot-path callers. `test/utils/dateHelper.test.js` adds 7 tests.
 
 ### Changed
 
@@ -22,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `userService.promoteOrganizationMember` and `userService.setOrganizationMemberActive` convert all user-facing throws to `UserFacingError` so messages such as "You cannot promote yourself" and "Target user not found" are preserved through `sanitizeError` instead of being redacted.
 - `teamService.promoteTeamMember` converts all user-facing throws to `UserFacingError` for the same reason; adds `UserFacingError` import to `teamService.js`.
 - `parseTimeString` catch blocks in `/dd-team-create` and `/dd-team-update` route through `sanitizeError` for pattern consistency (behavior unchanged since `TimeFormatError.userFacing === true`).
+- `standupService.getActiveMembers` batches its holiday and work-day lookups instead of calling the per-member async `isWorkingDay`, which re-fetched the same organization settings and per-user `workDays` every iteration. Query count is now O(1) in team size (~3 queries) instead of 2N+1 (~21 for a 10-person team, ~101 for 50). `isWorkingDay` is retained as a thin async wrapper for low-volume one-off callers and short-circuits on non-work days before its holiday query.
 
 ### Security
 

--- a/prisma/migrations/20260520044120_standup_response_team_date_index/migration.sql
+++ b/prisma/migrations/20260520044120_standup_response_team_date_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "standup_responses_team_id_standup_date_idx" ON "public"."standup_responses"("team_id", "standup_date");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -128,6 +128,7 @@ model StandupResponse {
 
   @@unique([teamId, userId, standupDate])
   @@index([standupDate])
+  @@index([teamId, standupDate])
   @@map("standup_responses")
 }
 

--- a/src/services/standupService.js
+++ b/src/services/standupService.js
@@ -4,7 +4,12 @@ const dayjs = require("dayjs");
 const utc = require("dayjs/plugin/utc");
 const timezone = require("dayjs/plugin/timezone");
 const advancedFormat = require("dayjs/plugin/advancedFormat");
-const { isWorkingDay } = require("../utils/dateHelper");
+const {
+  isWorkingDay,
+  isWorkingDayPure,
+  getHolidayDateSet,
+  getOrgDefaultWorkDays,
+} = require("../utils/dateHelper");
 const { getUserMention, getDisplayName } = require("../utils/userHelper");
 const { formatTasks } = require("../utils/messageHelper");
 const {
@@ -44,27 +49,27 @@ class StandupService {
       include: {
         user: true,
         team: {
-          include: {
-            organization: true,
-          },
+          include: { organization: true },
         },
       },
     });
 
-    // Filter by user's work days
-    const activeMembers = [];
-    for (const member of members) {
-      const isWorking = await isWorkingDay(
-        date,
-        member.team.organizationId,
-        member.userId
-      );
-      if (isWorking) {
-        activeMembers.push(member);
-      }
-    }
+    if (members.length === 0) return [];
 
-    return activeMembers;
+    // All members on the same team => same organization. Fetch org-default
+    // workDays and holidays once.
+    const organization = members[0].team.organization;
+    const orgDefaultWorkDays = getOrgDefaultWorkDays(organization.settings);
+    const holidayDateSet = await getHolidayDateSet(
+      organization.id,
+      startOfDay,
+      endOfDay
+    );
+
+    return members.filter((member) => {
+      const workDays = member.user.workDays || orgDefaultWorkDays;
+      return isWorkingDayPure({ date, workDays, holidayDateSet });
+    });
   }
 
   async saveResponse(

--- a/src/services/standupService.js
+++ b/src/services/standupService.js
@@ -67,7 +67,7 @@ class StandupService {
     );
 
     return members.filter((member) => {
-      const workDays = member.user.workDays || orgDefaultWorkDays;
+      const workDays = member.user.workDays?.length ? member.user.workDays : orgDefaultWorkDays;
       return isWorkingDayPure({ date, workDays, holidayDateSet });
     });
   }

--- a/src/utils/dateHelper.js
+++ b/src/utils/dateHelper.js
@@ -1,8 +1,10 @@
 const prisma = require("../config/prisma");
 const dayjs = require("dayjs");
 const weekday = require("dayjs/plugin/weekday");
+const utc = require("dayjs/plugin/utc");
 
 dayjs.extend(weekday);
+dayjs.extend(utc);
 
 const DEFAULT_WORK_DAYS = [1, 2, 3, 4, 7];
 
@@ -12,7 +14,7 @@ function getDayOfWeekIso(date) {
 }
 
 function toIsoDate(date) {
-  return dayjs(date).format("YYYY-MM-DD");
+  return dayjs.utc(date).format("YYYY-MM-DD");
 }
 
 /**
@@ -73,7 +75,7 @@ async function isWorkingDay(date, organizationId, userId = null) {
       where: { id: userId },
       select: { workDays: true },
     });
-    workDays = user?.workDays || null;
+    workDays = user?.workDays?.length ? user.workDays : null;
   }
 
   if (!workDays) {

--- a/src/utils/dateHelper.js
+++ b/src/utils/dateHelper.js
@@ -4,11 +4,70 @@ const weekday = require("dayjs/plugin/weekday");
 
 dayjs.extend(weekday);
 
-async function isWorkingDay(date, organizationId, userId = null) {
-  const dt = dayjs(date);
+const DEFAULT_WORK_DAYS = [1, 2, 3, 4, 7];
 
-  // Get work days - user-specific or organization default
-  let workDays;
+function getDayOfWeekIso(date) {
+  const dow = dayjs(date).day();
+  return dow === 0 ? 7 : dow;
+}
+
+function toIsoDate(date) {
+  return dayjs(date).format("YYYY-MM-DD");
+}
+
+/**
+ * Pure: does this date count as a working day given pre-loaded inputs?
+ * Use this inside loops where workDays + holidays have already been fetched.
+ */
+function isWorkingDayPure({ date, workDays, holidayDateSet }) {
+  const effectiveWorkDays =
+    Array.isArray(workDays) && workDays.length > 0
+      ? workDays
+      : DEFAULT_WORK_DAYS;
+
+  const dayOfWeek = getDayOfWeekIso(date);
+  if (!effectiveWorkDays.includes(dayOfWeek)) return false;
+
+  if (holidayDateSet && holidayDateSet.has(toIsoDate(date))) return false;
+
+  return true;
+}
+
+/**
+ * Batch helper: returns a Set of "YYYY-MM-DD" strings for the org's
+ * holidays within the (inclusive) date range.
+ */
+async function getHolidayDateSet(organizationId, startDate, endDate) {
+  const start = dayjs(startDate).startOf("day").toDate();
+  const end = dayjs(endDate).endOf("day").toDate();
+  const holidays = await prisma.holiday.findMany({
+    where: {
+      organization_id: organizationId,
+      date: { gte: start, lte: end },
+    },
+    select: { date: true },
+  });
+  return new Set(holidays.map((h) => toIsoDate(h.date)));
+}
+
+/**
+ * Convenience for org default work days. Returns the array stored in
+ * organization.settings.defaultWorkDays or the hardcoded fallback.
+ */
+function getOrgDefaultWorkDays(orgSettings) {
+  if (orgSettings && Array.isArray(orgSettings.defaultWorkDays)) {
+    return orgSettings.defaultWorkDays;
+  }
+  return DEFAULT_WORK_DAYS;
+}
+
+/**
+ * Original async wrapper. Kept for callers that don't pre-load inputs
+ * (one-off commands, tests, etc.). Hot-path callers should switch to
+ * isWorkingDayPure + getHolidayDateSet to avoid N+1 queries.
+ */
+async function isWorkingDay(date, organizationId, userId = null) {
+  let workDays = null;
   if (userId) {
     const user = await prisma.user.findUnique({
       where: { id: userId },
@@ -18,37 +77,28 @@ async function isWorkingDay(date, organizationId, userId = null) {
   }
 
   if (!workDays) {
-    // Use organization default
     const org = await prisma.organization.findUnique({
       where: { id: organizationId },
       select: { settings: true },
     });
-    workDays = org?.settings?.defaultWorkDays || [1, 2, 3, 4, 7];
+    workDays = getOrgDefaultWorkDays(org?.settings);
   }
 
-  // Check if current day is a work day (Day.js weekday: 0=Sunday, 1=Monday, etc.)
-  // Convert to match Luxon format (1=Monday, 7=Sunday)
-  const dayOfWeek = dt.day() === 0 ? 7 : dt.day();
-  if (!workDays.includes(dayOfWeek)) {
-    return false;
-  }
+  // Fast path: skip the holiday query when the day isn't a work day anyway.
+  const effectiveWorkDays =
+    Array.isArray(workDays) && workDays.length > 0
+      ? workDays
+      : DEFAULT_WORK_DAYS;
+  if (!effectiveWorkDays.includes(getDayOfWeekIso(date))) return false;
 
-  // Check holidays
-  const holiday = await prisma.holiday.findFirst({
-    where: {
-      organization_id: organizationId,
-      date: {
-        gte: dt.startOf("day").toDate(),
-        lte: dt.endOf("day").toDate(),
-      },
-    },
-  });
+  const dt = dayjs(date);
+  const holidayDateSet = await getHolidayDateSet(
+    organizationId,
+    dt.startOf("day").toDate(),
+    dt.endOf("day").toDate()
+  );
 
-  if (holiday) {
-    return false;
-  }
-
-  return true;
+  return isWorkingDayPure({ date, workDays, holidayDateSet });
 }
 
 /**
@@ -58,23 +108,12 @@ async function isWorkingDay(date, organizationId, userId = null) {
  */
 function formatTime12Hour(time24) {
   if (!time24 || typeof time24 !== "string") return time24;
-
-  // Validate time format and range
   if (!/^\d{1,2}:\d{2}$/.test(time24)) return time24;
-
   const [hours, minutes] = time24.split(":").map(Number);
-  if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) {
-    return time24;
-  }
-
+  if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return time24;
   try {
-    // Parse time using dayjs - create a date with the time
     const timeObj = dayjs(`2000-01-01 ${time24}`, "YYYY-MM-DD HH:mm", true);
-
-    // Check if the parsing was successful
     if (!timeObj.isValid()) return time24;
-
-    // Format to 12-hour format
     return timeObj.format("h:mm A");
   } catch (error) {
     return time24;
@@ -83,5 +122,9 @@ function formatTime12Hour(time24) {
 
 module.exports = {
   isWorkingDay,
+  isWorkingDayPure,
+  getDayOfWeekIso,
+  getHolidayDateSet,
+  getOrgDefaultWorkDays,
   formatTime12Hour,
 };

--- a/test/utils/dateHelper.test.js
+++ b/test/utils/dateHelper.test.js
@@ -1,0 +1,87 @@
+const {
+  isWorkingDayPure,
+  getDayOfWeekIso,
+} = require("../../src/utils/dateHelper");
+
+describe("getDayOfWeekIso", () => {
+  it("returns 1 for Monday, 7 for Sunday (ISO weekday)", () => {
+    // 2024-01-01 is a Monday
+    expect(getDayOfWeekIso(new Date("2024-01-01T12:00:00Z"))).toBe(1);
+    // 2024-01-07 is a Sunday
+    expect(getDayOfWeekIso(new Date("2024-01-07T12:00:00Z"))).toBe(7);
+  });
+});
+
+describe("isWorkingDayPure", () => {
+  // Mon 2024-01-01
+  const monday = new Date("2024-01-01T12:00:00Z");
+  // Sun 2024-01-07
+  const sunday = new Date("2024-01-07T12:00:00Z");
+
+  it("returns false when the weekday is not in workDays", () => {
+    expect(
+      isWorkingDayPure({
+        date: sunday,
+        workDays: [1, 2, 3, 4, 5],
+        holidayDateSet: new Set(),
+      })
+    ).toBe(false);
+  });
+
+  it("returns true when the weekday is in workDays and not a holiday", () => {
+    expect(
+      isWorkingDayPure({
+        date: monday,
+        workDays: [1, 2, 3, 4, 5],
+        holidayDateSet: new Set(),
+      })
+    ).toBe(true);
+  });
+
+  it("returns false when the date matches a holiday", () => {
+    expect(
+      isWorkingDayPure({
+        date: monday,
+        workDays: [1, 2, 3, 4, 5],
+        holidayDateSet: new Set(["2024-01-01"]),
+      })
+    ).toBe(false);
+  });
+
+  it("accepts Sunday=7 in workDays (legacy data uses [1,2,3,4,7])", () => {
+    expect(
+      isWorkingDayPure({
+        date: sunday,
+        workDays: [1, 2, 3, 4, 7],
+        holidayDateSet: new Set(),
+      })
+    ).toBe(true);
+  });
+
+  it("falls back to default [1,2,3,4,7] when workDays is null/undefined", () => {
+    expect(
+      isWorkingDayPure({
+        date: monday,
+        workDays: null,
+        holidayDateSet: new Set(),
+      })
+    ).toBe(true);
+    expect(
+      isWorkingDayPure({
+        date: new Date("2024-01-05T12:00:00Z"), // Friday = 5
+        workDays: null,
+        holidayDateSet: new Set(),
+      })
+    ).toBe(false);
+  });
+
+  it("falls back to default [1,2,3,4,7] when workDays is an empty array", () => {
+    expect(
+      isWorkingDayPure({
+        date: monday,
+        workDays: [],
+        holidayDateSet: new Set(),
+      })
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Stacked on top of #12 (`feat/security-correctness-hardening`). **Merge #12 first**, then this PR's base auto-retargets to `main`.

## Summary

Two independent query-performance fixes from the codebase review (Plan 2 of 4):

1. **Kills an N+1 in standup posting.** `standupService.getActiveMembers` called the async `isWorkingDay` once per team member, re-fetching the same org settings and per-user `workDays` every iteration — 2N+1 queries (~21 for a 10-person team, ~101 for 50). It now fetches the org's holidays once and runs a pure synchronous check per member: **O(1) in team size (~3 queries).**

2. **Adds a missing composite index.** `@@index([teamId, standupDate])` on `StandupResponse`. The existing `@@unique([teamId, userId, standupDate])` can't serve team + date-range queries without a `userId` — the shape used by `getTeamResponses`, `getLateResponses`, and the response counting in `postTeamStandup`.

## Changes

- `prisma/schema.prisma` + migration `20260520044120_standup_response_team_date_index` — single `CREATE INDEX`, nothing else.
- `src/utils/dateHelper.js` — `isWorkingDay` split into a pure core (`isWorkingDayPure`) + batch helpers (`getHolidayDateSet`, `getOrgDefaultWorkDays`). The async `isWorkingDay` wrapper keeps its exact signature for the remaining one-off callers and now short-circuits on non-work days before its holiday query.
- `src/services/standupService.js` — `getActiveMembers` refactored to the batch path.
- `test/utils/dateHelper.test.js` — 7 new unit tests for the pure core.

## Migration note

The new index applies on deploy via `prisma migrate deploy` (one `CREATE INDEX`, non-destructive, no downtime). During development the local Docker dev DB had to be reset to clear unrelated out-of-band `deleted_at` columns — that drift is a **separate, pre-existing issue** unrelated to this PR and does not affect production.

## Test plan

- [x] `npm test` — 4 suites, 39 tests passing
- [x] Migration SQL inspected — exactly one `CREATE INDEX`
- [x] `getActiveMembers` smoke test against local DB — no errors
- [ ] After deploy: confirm index exists (`\d standup_responses`) and standup posting behaves identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)