### PR TITLE
fix: remove invalid organization include in getUserBySlackId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `getUserBySlackId()` in `src/utils/permissionHelper.js` queried `prisma.user.findUnique()` with `include: { organization: true }`, but the `User` model has no singular `organization` relation (orgs are reached through the `organizations` / `OrganizationMember[]` junction). Prisma threw `PrismaClientValidationError`, which the helper's `catch` swallowed into `null`, causing `/dd-standup-post`, `/dd-standup-remind`, `/dd-standup-preview`, and `/dd-standup-followup` to report "User not found" for every user. Removed the broken (and unused — all callers read only `user.id`) `include`.
+
 ## [1.8.1] - 2026-05-27
 
 ### Added

--- a/src/utils/permissionHelper.js
+++ b/src/utils/permissionHelper.js
@@ -110,9 +110,6 @@ async function getUserBySlackId(slackUserId) {
   try {
     const user = await prisma.user.findUnique({
       where: { slackUserId },
-      include: {
-        organization: true,
-      },
     });
 
     return user;


### PR DESCRIPTION
## Summary

`getUserBySlackId()` in `src/utils/permissionHelper.js` queried `prisma.user.findUnique()` with `include: { organization: true }`, but the `User` model has **no** singular `organization` relation — orgs are reached through the `organizations` / `OrganizationMember[]` junction. Prisma threw `PrismaClientValidationError`, the helper's `catch` swallowed it into `null`, and the admin standup commands (`/dd-standup-post`, `/dd-standup-remind`, `/dd-standup-preview`, `/dd-standup-followup`) reported **"User not found"** for every user.

The `include` was also dead — all four callers in `src/commands/standup.js` read only `user.id` — so it's removed rather than corrected (avoids loading unused junction rows on a permission hot path).

## Scope check

Swept the whole codebase for the same stale-`organization`-include pattern (32 hits). Every other one correctly nests `organization` under `team` or under the `organizations` junction. This was the only broken instance.

## Verification

- `npm test` — 53/53 pass
- `npx eslint src/utils/permissionHelper.js` — clean
- CHANGELOG.md `[Unreleased]` updated with a `Fixed` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where Slack standup commands were incorrectly reporting "User not found" for all users due to invalid database query configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->