### PR TITLE
feat: preview & post an individual member's standup via @mention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `/dd-standup-preview` and `/dd-standup-post` now accept an optional `@mention` to preview or post a single team member's standup. Preview is ephemeral; post appends the member's response as a threaded reply under the day's team standup post (`reply_broadcast: true`), auto-posting the team summary first if no thread exists yet. New `standupService.getUserResponse`, `formatIndividualResponseMessage`, and `postIndividualResponse`; `teamHelper.parseCommandArguments` now returns `mentionedUserId`; reuses `blockHelper.createUserResponseBlocks` (no admin label). Always appends — no dedup. (`src/commands/standup.js`, `src/services/standupService.js`, `src/utils/teamHelper.js`)
+
+### Changed
+
+- `permissionHelper.canManageTeam` now grants management to organization **admins** (`OrgRole.ADMIN`), not just owners and team admins — applies to all admin commands. New `isOrganizationAdmin` helper. (`src/utils/permissionHelper.js`)
+
 ## [1.8.7] - 2026-06-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ These commands allow team admins and organization owners to manually trigger sta
 **Permission Requirements:**
 
 - **Team Admins**: Can use commands in their team's channel without specifying team name
-- **Organization Admins**: Can use commands from any channel (same access as owners)
+- **Organization Admins**: Can run admin commands in any team's channel without specifying a team name (channel-based resolution, like team admins), for any team in the organization — or specify a team name explicitly to act from any channel
 - **Organization Owners**: Can use commands from any channel but must specify team name
 
 #### Command Overview

--- a/README.md
+++ b/README.md
@@ -190,13 +190,14 @@ These commands allow team admins and organization owners to manually trigger sta
 **Permission Requirements:**
 
 - **Team Admins**: Can use commands in their team's channel without specifying team name
+- **Organization Admins**: Can use commands from any channel (same access as owners)
 - **Organization Owners**: Can use commands from any channel but must specify team name
 
 #### Command Overview
 
 - `/dd-standup-remind [team-name]` - Send standup reminders to team members ⚠️ **(admin/owner only)**
-- `/dd-standup-post [YYYY-MM-DD] [team-name]` - Post standup summary to channel ⚠️ **(admin/owner only)**
-- `/dd-standup-preview [YYYY-MM-DD] [team-name]` - Preview standup summary before posting ⚠️ **(admin/owner only)**
+- `/dd-standup-post [@user] [YYYY-MM-DD] [team-name]` - Post standup summary to channel, or append a single member's standup as a threaded reply when you @mention them ⚠️ **(admin/owner only)**
+- `/dd-standup-preview [@user] [YYYY-MM-DD] [team-name]` - Preview the team summary, or a single member's standup when you @mention them (ephemeral) ⚠️ **(admin/owner only)**
 - `/dd-standup-followup [team-name]` - Send followup reminders to non-responders ⚠️ **(admin/owner only)**
 
 #### Context-Aware Behavior
@@ -259,11 +260,12 @@ These commands allow team admins and organization owners to manually trigger sta
   - Send additional reminders if team members forgot
   - Test reminder functionality for new teams
 
-**Standup Post** - `/dd-standup-post [YYYY-MM-DD] [team-name]`
+**Standup Post** - `/dd-standup-post [@user] [YYYY-MM-DD] [team-name]`
 
-- **Purpose**: Manually post standup summary to the team channel
+- **Purpose**: Manually post standup summary to the team channel, or append a single member's standup as a threaded reply
 - **Date format**: YYYY-MM-DD (e.g., 2024-12-20)
 - **Default**: Posts today's standup if no date specified
+- **Individual post**: When an @mention is provided, appends that member's standup response as a threaded reply under the day's team standup post (broadcast to channel). If no team standup thread exists yet for that date, the team summary is auto-posted first to create the thread.
 - **Context-aware**:
   - Admins in team channel: `/dd-standup-post` or `/dd-standup-post 2024-12-20`
   - Owners from anywhere: `/dd-standup-post Engineering` or `/dd-standup-post 2024-12-20 Engineering`
@@ -271,13 +273,15 @@ These commands allow team admins and organization owners to manually trigger sta
   - Post summary early before scheduled posting time
   - Re-post summary if original was deleted
   - Post past standup summaries that were missed
+  - Share a single team member's standup into the thread on demand
 
-**Standup Preview** - `/dd-standup-preview [YYYY-MM-DD] [team-name]`
+**Standup Preview** - `/dd-standup-preview [@user] [YYYY-MM-DD] [team-name]`
 
 - **Purpose**: Preview standup summary before posting to channel (ephemeral message)
 - **Date format**: YYYY-MM-DD (e.g., 2024-12-20)
 - **Default**: Previews today's standup if no date specified
 - **Visibility**: Only visible to you (ephemeral)
+- **Individual preview**: When an @mention is provided, previews only that member's standup response instead of the full team summary (still ephemeral).
 - **Context-aware**:
   - Admins in team channel: `/dd-standup-preview` or `/dd-standup-preview 2024-12-20`
   - Owners from anywhere: `/dd-standup-preview Engineering` or `/dd-standup-preview 2024-12-20 Engineering`
@@ -285,6 +289,7 @@ These commands allow team admins and organization owners to manually trigger sta
   - Check what the summary looks like before posting
   - Verify all expected submissions are included
   - Review standup data without posting to channel
+  - Inspect a specific team member's standup privately
 
 **Standup Followup** - `/dd-standup-followup [team-name]`
 

--- a/docs/superpowers/plans/2026-06-08-admin-individual-standup.md
+++ b/docs/superpowers/plans/2026-06-08-admin-individual-standup.md
@@ -1,0 +1,931 @@
+# Admin Individual Standup Preview/Post — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an admin (org owner, org admin, or team admin) preview and post a single team member's standup by adding an optional `@mention` to the existing `/dd-standup-preview` and `/dd-standup-post` commands.
+
+**Architecture:** Extend the argument parser to surface a mentioned Slack user; broaden the shared `canManageTeam` gate to include org admins; add two `standupService` methods (`getUserResponse`, `postIndividualResponse`) plus a formatter; branch the two command handlers on the presence of a mention. Individual posting appends the member's standup as a threaded reply under the day's team post, auto-creating that post if it doesn't exist yet. No schema changes.
+
+**Tech Stack:** Node.js, Slack Bolt, Prisma/PostgreSQL, dayjs, Jest.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-admin-individual-standup-design.md`
+
+---
+
+## File Structure
+
+- `src/utils/permissionHelper.js` — add `isOrganizationAdmin`; broaden `canManageTeam`; export helper. (Task 1)
+- `src/utils/teamHelper.js` — `parseCommandArguments` returns `mentionedUserId`. (Task 2)
+- `src/services/standupService.js` — `getUserResponse`, `formatIndividualResponseMessage`, `postIndividualResponse`. (Tasks 3–5)
+- `src/commands/standup.js` — `resolveTargetMember` helper; individual branches in `previewStandup` and `postStandup`. (Tasks 6–7)
+- `README.md`, `CHANGELOG.md`, `web/src/data/changelog.json` — docs. (Task 8)
+- Tests: `test/utils/permissionHelper.test.js`, `test/utils/teamHelper.test.js`, `test/services/standupServiceIndividual.test.js`.
+
+---
+
+## Task 1: Broaden permission to include org admins
+
+**Files:**
+
+- Modify: `src/utils/permissionHelper.js`
+- Test: `test/utils/permissionHelper.test.js` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/utils/permissionHelper.test.js`:
+
+```js
+jest.mock("../../src/config/prisma", () => ({
+  team: { findFirst: jest.fn() },
+  organizationMember: { findUnique: jest.fn() },
+  teamMember: { findFirst: jest.fn() },
+  user: { findUnique: jest.fn() },
+}));
+
+const prisma = require("../../src/config/prisma");
+const {
+  canManageTeam,
+  isOrganizationAdmin,
+} = require("../../src/utils/permissionHelper");
+
+describe("canManageTeam org admin access", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("grants management to an active org admin", async () => {
+    prisma.team.findFirst.mockResolvedValue({ organizationId: "o1" });
+    // Both the owner check and the admin check call findUnique; ADMIN role
+    // fails the owner check (role !== OWNER) and passes the admin check.
+    prisma.organizationMember.findUnique.mockResolvedValue({
+      role: "ADMIN",
+      isActive: true,
+    });
+    prisma.teamMember.findFirst.mockResolvedValue(null);
+
+    const res = await canManageTeam("u1", "t1");
+    expect(res).toMatchObject({ canManage: true, role: "ORG_ADMIN" });
+  });
+
+  it("denies a plain org member who is not a team admin", async () => {
+    prisma.team.findFirst.mockResolvedValue({ organizationId: "o1" });
+    prisma.organizationMember.findUnique.mockResolvedValue({
+      role: "MEMBER",
+      isActive: true,
+    });
+    prisma.teamMember.findFirst.mockResolvedValue(null);
+
+    const res = await canManageTeam("u1", "t1");
+    expect(res.canManage).toBe(false);
+  });
+
+  it("isOrganizationAdmin is false for an inactive admin", async () => {
+    prisma.organizationMember.findUnique.mockResolvedValue({
+      role: "ADMIN",
+      isActive: false,
+    });
+    expect(await isOrganizationAdmin("u1", "o1")).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest test/utils/permissionHelper.test.js`
+Expected: FAIL — `isOrganizationAdmin is not a function` / `role` is not `"ORG_ADMIN"`.
+
+- [ ] **Step 3: Add `isOrganizationAdmin` and broaden `canManageTeam`**
+
+In `src/utils/permissionHelper.js`, add this function immediately after `isOrganizationOwner`:
+
+```js
+async function isOrganizationAdmin(userId, organizationId) {
+  try {
+    const membership = await prisma.organizationMember.findUnique({
+      where: { organizationId_userId: { organizationId, userId } },
+      select: { role: true, isActive: true },
+    });
+
+    return !!membership && membership.isActive && membership.role === "ADMIN";
+  } catch (error) {
+    console.error("Error checking organization admin:", error);
+    return false;
+  }
+}
+```
+
+In `canManageTeam`, insert this block between the owner check and the team-admin check (i.e. directly after the `if (isOwner) { ... }` block):
+
+```js
+// Check if user is an organization admin
+const isOrgAdmin = await isOrganizationAdmin(userId, team.organizationId);
+if (isOrgAdmin) {
+  return {
+    canManage: true,
+    role: "ORG_ADMIN",
+    reason: null,
+  };
+}
+```
+
+Add `isOrganizationAdmin` to `module.exports` (alongside `isOrganizationOwner`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest test/utils/permissionHelper.test.js`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/permissionHelper.js test/utils/permissionHelper.test.js
+git commit -m "feat: grant org admins team-management permission"
+```
+
+---
+
+## Task 2: Parse a mentioned user from command text
+
+**Files:**
+
+- Modify: `src/utils/teamHelper.js` (`parseCommandArguments`, ~line 192)
+- Test: `test/utils/teamHelper.test.js` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/utils/teamHelper.test.js`:
+
+```js
+const { parseCommandArguments } = require("../../src/utils/teamHelper");
+
+describe("parseCommandArguments mention extraction", () => {
+  it("returns null mentionedUserId when no mention present", () => {
+    expect(parseCommandArguments("2025-01-15 Engineering")).toEqual({
+      date: "2025-01-15",
+      teamName: "Engineering",
+      mentionedUserId: null,
+    });
+  });
+
+  it("extracts a mention with a pipe label and keeps date + team", () => {
+    const res = parseCommandArguments(
+      "<@U123ABC|alice> 2025-01-15 Engineering"
+    );
+    expect(res).toEqual({
+      date: "2025-01-15",
+      teamName: "Engineering",
+      mentionedUserId: "U123ABC",
+    });
+  });
+
+  it("extracts a bare mention with no label", () => {
+    const res = parseCommandArguments("<@U999>");
+    expect(res).toEqual({
+      date: null,
+      teamName: null,
+      mentionedUserId: "U999",
+    });
+  });
+
+  it("uses the first mention when several are present", () => {
+    const res = parseCommandArguments("<@U111|a> <@U222|b>");
+    expect(res.mentionedUserId).toBe("U111");
+  });
+
+  it("returns all-null for empty input", () => {
+    expect(parseCommandArguments("")).toEqual({
+      date: null,
+      teamName: null,
+      mentionedUserId: null,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest test/utils/teamHelper.test.js`
+Expected: FAIL — result objects lack `mentionedUserId`.
+
+- [ ] **Step 3: Update `parseCommandArguments`**
+
+Replace the body of `parseCommandArguments` in `src/utils/teamHelper.js` with:
+
+```js
+function parseCommandArguments(commandText) {
+  if (!commandText || !commandText.trim()) {
+    return { date: null, teamName: null, mentionedUserId: null };
+  }
+
+  let text = commandText.trim();
+  let date = null;
+  let teamName = null;
+  let mentionedUserId = null;
+
+  // Mention pattern: <@U123> or <@U123|name>. Use the first, strip all.
+  const mentionPattern = /<@([A-Z0-9]+)(?:\|[^>]+)?>/g;
+  const mentionMatch = text.match(mentionPattern);
+  if (mentionMatch) {
+    const first = /<@([A-Z0-9]+)(?:\|[^>]+)?>/.exec(mentionMatch[0]);
+    mentionedUserId = first[1];
+    text = text.replace(mentionPattern, "").trim();
+  }
+
+  // Date pattern: YYYY-MM-DD
+  const datePattern = /\b(\d{4}-\d{2}-\d{2})\b/;
+  const dateMatch = text.match(datePattern);
+
+  if (dateMatch) {
+    date = dateMatch[1];
+    const remainingText = text.replace(dateMatch[0], "").trim();
+    if (remainingText) {
+      teamName = parseTeamName(remainingText);
+    }
+  } else if (text) {
+    teamName = parseTeamName(text);
+  }
+
+  return { date, teamName, mentionedUserId };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest test/utils/teamHelper.test.js`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Run the full suite to confirm no regressions**
+
+Run: `npm test`
+Expected: PASS (existing callers ignore the new field).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/teamHelper.js test/utils/teamHelper.test.js
+git commit -m "feat: parse mentioned user from standup command args"
+```
+
+---
+
+## Task 3: `standupService.getUserResponse`
+
+**Files:**
+
+- Modify: `src/services/standupService.js` (add method after `getLateResponses`, ~line 163)
+- Test: `test/services/standupServiceIndividual.test.js` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/services/standupServiceIndividual.test.js`:
+
+```js
+jest.mock("../../src/config/prisma", () => ({
+  standupResponse: { findFirst: jest.fn(), findMany: jest.fn() },
+  standupPost: { findUnique: jest.fn(), upsert: jest.fn() },
+  team: { findUnique: jest.fn() },
+  teamMember: { findMany: jest.fn() },
+  holiday: { findMany: jest.fn() },
+  user: { findUnique: jest.fn() },
+  organization: { findUnique: jest.fn() },
+}));
+
+const prisma = require("../../src/config/prisma");
+const standupService = require("../../src/services/standupService");
+
+describe("getUserResponse", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("queries the member's response for the date window", async () => {
+    const row = { id: "r1", user: { slackUserId: "U1" } };
+    prisma.standupResponse.findFirst.mockResolvedValue(row);
+
+    const result = await standupService.getUserResponse(
+      "t1",
+      "u1",
+      new Date("2025-01-15T10:00:00Z")
+    );
+
+    expect(result).toBe(row);
+    const arg = prisma.standupResponse.findFirst.mock.calls[0][0];
+    expect(arg.where.teamId).toBe("t1");
+    expect(arg.where.userId).toBe("u1");
+    expect(arg.where.standupDate.gte).toBeInstanceOf(Date);
+    expect(arg.where.standupDate.lte).toBeInstanceOf(Date);
+    expect(arg.include).toEqual({ user: true });
+  });
+
+  it("returns null when there is no response", async () => {
+    prisma.standupResponse.findFirst.mockResolvedValue(null);
+    const result = await standupService.getUserResponse("t1", "u1", new Date());
+    expect(result).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest test/services/standupServiceIndividual.test.js -t getUserResponse`
+Expected: FAIL — `getUserResponse is not a function`.
+
+- [ ] **Step 3: Implement `getUserResponse`**
+
+In `src/services/standupService.js`, add this method directly after `getLateResponses`:
+
+```js
+  async getUserResponse(teamId, userId, date) {
+    const startOfDay = dayjs(date).startOf("day").toDate();
+    const endOfDay = dayjs(date).endOf("day").toDate();
+
+    return await prisma.standupResponse.findFirst({
+      where: {
+        teamId,
+        userId,
+        standupDate: {
+          gte: startOfDay,
+          lte: endOfDay,
+        },
+      },
+      include: {
+        user: true,
+      },
+      orderBy: {
+        submittedAt: "desc",
+      },
+    });
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest test/services/standupServiceIndividual.test.js -t getUserResponse`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/standupService.js test/services/standupServiceIndividual.test.js
+git commit -m "feat: add getUserResponse to standup service"
+```
+
+---
+
+## Task 4: `standupService.formatIndividualResponseMessage`
+
+**Files:**
+
+- Modify: `src/services/standupService.js` (import `createUserResponseBlocks`; add method after `formatLateResponseMessage`, ~line 353)
+- Test: `test/services/standupServiceIndividual.test.js` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/services/standupServiceIndividual.test.js`:
+
+```js
+describe("formatIndividualResponseMessage", () => {
+  it("returns text and blocks with the member section, no admin label", async () => {
+    const response = {
+      user: { slackUserId: "U1", name: "Alice" },
+      yesterdayTasks: "shipped X",
+      todayTasks: "review Y",
+      blockers: null,
+    };
+
+    const msg = await standupService.formatIndividualResponseMessage(response);
+
+    expect(typeof msg.text).toBe("string");
+    expect(Array.isArray(msg.blocks)).toBe(true);
+    // First block is the member header section "*👤 <@U1>*"
+    expect(msg.blocks[0].text.text).toContain("<@U1>");
+    // No "Late Submission" / "posted by admin" labelling anywhere
+    const serialized = JSON.stringify(msg.blocks);
+    expect(serialized).not.toContain("Late Submission");
+    expect(serialized.toLowerCase()).not.toContain("posted by admin");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest test/services/standupServiceIndividual.test.js -t formatIndividualResponseMessage`
+Expected: FAIL — `formatIndividualResponseMessage is not a function`.
+
+- [ ] **Step 3: Implement the formatter**
+
+In `src/services/standupService.js`, add `createUserResponseBlocks` to the destructured `blockHelper` import (the block at lines ~16-23):
+
+```js
+const {
+  createSectionBlock,
+  createTaskFieldBlocks,
+  createDividerBlock,
+  createLateResponseBlocks,
+  createUserResponseBlocks,
+  createNotRespondedBlocks,
+  createOnLeaveBlocks,
+} = require("../utils/blockHelper");
+```
+
+Add this method directly after `formatLateResponseMessage`:
+
+```js
+  async formatIndividualResponseMessage(response) {
+    const responseData = {
+      userMention: getUserMention(response.user),
+      yesterdayTasks: formatTasks(response.yesterdayTasks),
+      todayTasks: formatTasks(response.todayTasks),
+      blockers: response.blockers,
+    };
+
+    return {
+      text: `Standup from ${getDisplayName(response.user)}`,
+      blocks: createUserResponseBlocks(responseData),
+    };
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest test/services/standupServiceIndividual.test.js -t formatIndividualResponseMessage`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/standupService.js test/services/standupServiceIndividual.test.js
+git commit -m "feat: add individual standup response formatter"
+```
+
+---
+
+## Task 5: `standupService.postIndividualResponse`
+
+**Files:**
+
+- Modify: `src/services/standupService.js` (add method after `postLateResponses`, ~line 665)
+- Test: `test/services/standupServiceIndividual.test.js` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/services/standupServiceIndividual.test.js`:
+
+```js
+describe("postIndividualResponse", () => {
+  const team = { id: "t1", name: "Eng", slackChannelId: "C1" };
+  const response = {
+    user: { slackUserId: "U1", name: "Alice" },
+    yesterdayTasks: "a",
+    todayTasks: "b",
+    blockers: null,
+  };
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it("appends a threaded reply when a thread already exists", async () => {
+    jest
+      .spyOn(standupService, "getStandupPost")
+      .mockResolvedValue({ slackMessageTs: "111.1", channelId: "C1" });
+    const postTeam = jest
+      .spyOn(standupService, "postTeamStandup")
+      .mockResolvedValue({});
+    const postMessage = jest.fn().mockResolvedValue({ ts: "222.2" });
+    const slackApp = { client: { chat: { postMessage } } };
+
+    const result = await standupService.postIndividualResponse(
+      team,
+      new Date("2025-01-15"),
+      response,
+      slackApp
+    );
+
+    expect(postTeam).not.toHaveBeenCalled();
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C1",
+        thread_ts: "111.1",
+        reply_broadcast: true,
+      })
+    );
+    expect(result).toMatchObject({ ts: "222.2", channel: "C1" });
+  });
+
+  it("auto-posts the team summary first when no thread exists", async () => {
+    jest
+      .spyOn(standupService, "getStandupPost")
+      .mockResolvedValueOnce(null) // before
+      .mockResolvedValueOnce({ slackMessageTs: "333.3", channelId: "C1" }); // after
+    const postTeam = jest
+      .spyOn(standupService, "postTeamStandup")
+      .mockResolvedValue({});
+    const postMessage = jest.fn().mockResolvedValue({ ts: "444.4" });
+    const slackApp = { client: { chat: { postMessage } } };
+
+    await standupService.postIndividualResponse(
+      team,
+      new Date("2025-01-15"),
+      response,
+      slackApp
+    );
+
+    expect(postTeam).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ thread_ts: "333.3", reply_broadcast: true })
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest test/services/standupServiceIndividual.test.js -t postIndividualResponse`
+Expected: FAIL — `postIndividualResponse is not a function`.
+
+- [ ] **Step 3: Implement `postIndividualResponse`**
+
+In `src/services/standupService.js`, add this method directly after `postLateResponses` (just before the closing `}` of the class):
+
+```js
+  async postIndividualResponse(team, date, response, slackApp) {
+    // Ensure a team standup thread exists; auto-create it if missing.
+    let standupPost = await this.getStandupPost(team.id, date);
+    if (!standupPost || !standupPost.slackMessageTs) {
+      await this.postTeamStandup(team, date, slackApp);
+      standupPost = await this.getStandupPost(team.id, date);
+    }
+
+    if (!standupPost || !standupPost.slackMessageTs) {
+      throw new Error("Could not find or create a standup thread to post into");
+    }
+
+    const message = await this.formatIndividualResponseMessage(response);
+
+    const result = await slackApp.client.chat.postMessage({
+      channel: standupPost.channelId,
+      thread_ts: standupPost.slackMessageTs,
+      reply_broadcast: true,
+      ...message,
+    });
+
+    return { ts: result.ts, channel: standupPost.channelId };
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest test/services/standupServiceIndividual.test.js`
+Expected: PASS (all describes).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/standupService.js test/services/standupServiceIndividual.test.js
+git commit -m "feat: post an individual standup into the team thread"
+```
+
+---
+
+## Task 6: Individual branch in `previewStandup` + shared member resolver
+
+**Files:**
+
+- Modify: `src/commands/standup.js` — add `resolveTargetMember` helper; update `previewStandup` (~line 900) to destructure `mentionedUserId` and branch.
+
+No unit test (command handlers aren't unit-tested in this repo, consistent with existing code). Verified by the unit-tested helpers above plus manual Slack testing in Step 4.
+
+- [ ] **Step 1: Add the `resolveTargetMember` helper**
+
+In `src/commands/standup.js`, add this function near the other module-level helpers (e.g. directly above `previewStandup`):
+
+```js
+/**
+ * Resolve a mentioned Slack user to an active member of the given team.
+ * @returns {Promise<{targetUser?: object, error?: string}>}
+ */
+async function resolveTargetMember(teamId, mentionedUserId) {
+  const targetUser = await getUserBySlackId(mentionedUserId);
+  if (!targetUser) {
+    return { error: "That user isn't registered in the system." };
+  }
+
+  const membership = await prisma.teamMember.findUnique({
+    where: { teamId_userId: { teamId, userId: targetUser.id } },
+  });
+
+  if (!membership || !membership.isActive) {
+    return { error: "That user isn't an active member of this team." };
+  }
+
+  return { targetUser };
+}
+```
+
+- [ ] **Step 2: Destructure `mentionedUserId` in `previewStandup`**
+
+In `previewStandup`, change the argument parse line:
+
+```js
+const { date: dateStr, teamName } = parseCommandArguments(command.text);
+```
+
+to:
+
+```js
+const {
+  date: dateStr,
+  teamName,
+  mentionedUserId,
+} = parseCommandArguments(command.text);
+```
+
+- [ ] **Step 3: Add the individual branch**
+
+In `previewStandup`, immediately after the `targetDate` is computed:
+
+```js
+// Determine target date
+const targetDate = dateStr
+  ? dayjs(dateStr).tz(team.timezone)
+  : dayjs().tz(team.timezone);
+```
+
+insert:
+
+```js
+// Individual member preview
+if (mentionedUserId) {
+  const { targetUser, error: memberError } = await resolveTargetMember(
+    team.id,
+    mentionedUserId
+  );
+  if (memberError) {
+    await updateResponse({
+      blocks: createCommandErrorBlocks(memberError),
+      response_type: "ephemeral",
+    });
+    return;
+  }
+
+  const response = await standupService.getUserResponse(
+    team.id,
+    targetUser.id,
+    targetDate.toDate()
+  );
+  if (!response) {
+    await updateResponse({
+      blocks: createNoDataBlocks(
+        `standup from ${getUserMention(targetUser)}`,
+        targetDate.format("MMM DD, YYYY")
+      ),
+      response_type: "ephemeral",
+    });
+    return;
+  }
+
+  const message =
+    await standupService.formatIndividualResponseMessage(response);
+
+  await updateResponse({
+    blocks: [
+      createSectionBlock(
+        `🔍 *Preview — ${getUserMention(targetUser)}'s standup* · ${targetDate.format(
+          "MMM DD, YYYY"
+        )}`
+      ),
+      ...message.blocks,
+    ],
+    response_type: "ephemeral",
+  });
+
+  console.log(
+    `🔍 ${getUserLogIdentifier(user)} previewed ${getUserMention(
+      targetUser
+    )}'s standup for team ${team.name} (${targetDate.format("YYYY-MM-DD")})`
+  );
+  return;
+}
+```
+
+- [ ] **Step 4: Manual verification**
+
+Run: `npm test` (confirm nothing broke).
+Then in Slack (admin in a team channel):
+
+- `/dd-standup-preview @someMember` → ephemeral preview of that member's standup, with the "Preview — …" header.
+- `/dd-standup-preview @nonMember` → "isn't an active member" error.
+- `/dd-standup-preview @memberWithNoSubmission` → "No data" message.
+- `/dd-standup-preview` (no mention) → unchanged team preview.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commands/standup.js
+git commit -m "feat: preview an individual member's standup via mention"
+```
+
+---
+
+## Task 7: Individual branch in `postStandup`
+
+**Files:**
+
+- Modify: `src/commands/standup.js` — update `postStandup` (~line 764) to destructure `mentionedUserId` and branch (ephemeral errors + success).
+
+No unit test (command handler); verified by service unit tests + manual Slack testing in Step 3.
+
+- [ ] **Step 1: Destructure `mentionedUserId` in `postStandup`**
+
+In `postStandup`, change:
+
+```js
+const { date: dateStr, teamName } = parseCommandArguments(command.text);
+```
+
+to:
+
+```js
+const {
+  date: dateStr,
+  teamName,
+  mentionedUserId,
+} = parseCommandArguments(command.text);
+```
+
+- [ ] **Step 2: Add the individual branch**
+
+In `postStandup`, immediately after the `targetDate` is computed:
+
+```js
+// Determine target date
+const targetDate = dateStr
+  ? dayjs(dateStr).tz(team.timezone)
+  : dayjs().tz(team.timezone);
+```
+
+insert:
+
+```js
+// Individual member post (ephemeral errors + confirmation)
+if (mentionedUserId) {
+  const { targetUser, error: memberError } = await resolveTargetMember(
+    team.id,
+    mentionedUserId
+  );
+  if (memberError) {
+    await updateResponse({
+      blocks: createCommandErrorBlocks(memberError),
+      response_type: "ephemeral",
+    });
+    return;
+  }
+
+  const response = await standupService.getUserResponse(
+    team.id,
+    targetUser.id,
+    targetDate.toDate()
+  );
+  if (!response) {
+    await updateResponse({
+      blocks: createNoDataBlocks(
+        `standup from ${getUserMention(targetUser)}`,
+        targetDate.format("MMM DD, YYYY")
+      ),
+      response_type: "ephemeral",
+    });
+    return;
+  }
+
+  const result = await standupService.postIndividualResponse(
+    team,
+    targetDate.toDate(),
+    response,
+    { client }
+  );
+
+  await updateResponse({
+    blocks: createCommandSuccessBlocks(
+      `Posted ${getUserMention(targetUser)}'s standup to *${team.name}*`,
+      {
+        Date: targetDate.format("MMM DD, YYYY"),
+        "Message timestamp": result.ts,
+      }
+    ),
+    response_type: "ephemeral",
+  });
+
+  console.log(
+    `📊 ${getUserLogIdentifier(user)} posted ${getUserMention(
+      targetUser
+    )}'s standup for team ${team.name} (${targetDate.format("YYYY-MM-DD")})`
+  );
+  return;
+}
+```
+
+- [ ] **Step 3: Manual verification**
+
+Run: `npm test` (confirm nothing broke).
+Then in Slack (admin in a team channel):
+
+- With an existing team standup posted today: `/dd-standup-post @member` → adds a threaded reply (broadcast to channel) with that member's standup; ephemeral success to admin.
+- With NO team standup posted yet today: `/dd-standup-post @member` → posts the team summary (creating the thread), then adds the member reply.
+- `/dd-standup-post @member` again → a second reply appended (no dedup), as designed.
+- `/dd-standup-post @nonMember` → ephemeral "isn't an active member" error.
+- `/dd-standup-post` (no mention) → unchanged team post.
+- As an **org admin** (OrgRole ADMIN, not owner, not team admin): the above commands are now permitted.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/commands/standup.js
+git commit -m "feat: post an individual member's standup via mention"
+```
+
+---
+
+## Task 8: Documentation
+
+**Files:**
+
+- Modify: `README.md`, `CHANGELOG.md`, `web/src/data/changelog.json`
+
+- [ ] **Step 1: README — document the `@user` form**
+
+Find the sections describing `/dd-standup-preview` and `/dd-standup-post` in `README.md` and add the mention form. Example additions (adapt to surrounding wording):
+
+```markdown
+- `/dd-standup-preview [@user] [date] [team-name]` — Preview the team summary, or a single member's standup when you @mention them (ephemeral).
+- `/dd-standup-post [@user] [date] [team-name]` — Post the team summary, or append a single member's standup into the day's team thread when you @mention them. If no team standup exists yet for the date, the summary is posted first to create the thread.
+```
+
+Also note org-admin access where command permissions are described: "Org owners, org admins, and team admins can run admin commands."
+
+- [ ] **Step 2: CHANGELOG.md — technical entry under `[Unreleased]`**
+
+Add under `## [Unreleased]` (create `### Added` / `### Changed` as needed):
+
+```markdown
+### Added
+
+- `/dd-standup-preview` and `/dd-standup-post` now accept an optional `@mention` to preview or post a single team member's standup. Preview is ephemeral; post appends the member's response as a threaded reply under the day's team standup post (`reply_broadcast: true`), auto-posting the team summary first if no thread exists yet. New `standupService.getUserResponse`, `formatIndividualResponseMessage`, and `postIndividualResponse`; argument parsing in `teamHelper.parseCommandArguments` now returns `mentionedUserId`; reuses `blockHelper.createUserResponseBlocks` (no admin label). Always appends — no dedup. (`src/commands/standup.js`, `src/services/standupService.js`, `src/utils/teamHelper.js`)
+
+### Changed
+
+- `permissionHelper.canManageTeam` now grants management to organization **admins** (`OrgRole.ADMIN`), not just owners and team admins — applies to all admin commands. New `isOrganizationAdmin` helper. (`src/utils/permissionHelper.js`)
+```
+
+- [ ] **Step 3: changelog.json — user-facing entry**
+
+Add a new entry at the top of the `versions` array in `web/src/data/changelog.json`, set its `isLatest: true`, and set the previously-latest entry's `isLatest: false`. Use the next version number (decided at release time — use a placeholder section the release skill will reconcile, or coordinate with the maintainer). Entry content:
+
+```json
+{
+  "version": "UNRELEASED",
+  "date": "2026-06-08",
+  "isLatest": true,
+  "changes": [
+    {
+      "type": "added",
+      "title": "Preview and post a single member's standup",
+      "items": [
+        "Admins can now preview or post one team member's standup by mentioning them, e.g. /dd-standup-preview @alice or /dd-standup-post @alice",
+        "Posting a member adds their update as a reply under the day's team standup"
+      ]
+    },
+    {
+      "type": "changed",
+      "title": "Organization admins get admin access",
+      "items": [
+        "Organization admins can now run admin standup commands, alongside owners and team admins"
+      ]
+    }
+  ]
+}
+```
+
+> Note: this repo versions/changelogs via the `/release` skill. Leave the `version` as `UNRELEASED` here and let the release flow assign the real number, or set it to the agreed next version. Do not flip `isLatest` on a released entry without bumping the version.
+
+- [ ] **Step 4: Validate JSON**
+
+Run: `node -e "JSON.parse(require('fs').readFileSync('web/src/data/changelog.json','utf8')); console.log('valid')"`
+Expected: `valid`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md CHANGELOG.md web/src/data/changelog.json
+git commit -m "docs: document individual standup preview/post and org-admin access"
+```
+
+---
+
+## Final verification
+
+- [ ] Run the full test suite: `npm test` — Expected: all pass.
+- [ ] Run lint: `npm run lint` — Expected: clean.
+- [ ] Manual Slack smoke test of both commands (mention + no-mention paths, org-admin role) per Tasks 6–7.
+
+---
+
+## Self-Review Notes (author)
+
+- **Spec coverage:** permission broadening (Task 1), mention parsing (Task 2), preview flow (Task 6), post flow incl. auto-thread + always-append (Tasks 5, 7), no admin label (Task 4 reuses `createUserResponseBlocks`), ephemeral individual errors/success (Tasks 6–7), tests (Tasks 1–5), docs (Task 8). Edge cases (not-a-member, no-submission, multiple mentions, self-post, no-thread) all covered.
+- **Type consistency:** `mentionedUserId` returned by `parseCommandArguments` and consumed in both handlers; `resolveTargetMember(teamId, mentionedUserId) -> {targetUser?, error?}` used identically in Tasks 6–7; `getUserResponse(teamId, userId, date)`, `formatIndividualResponseMessage(response) -> {text, blocks}`, `postIndividualResponse(team, date, response, slackApp) -> {ts, channel}` consistent across definition and call sites; role label `"ORG_ADMIN"`.
+- **No placeholders** except the deliberate `changelog.json` version, which this repo intentionally assigns via the `/release` skill.

--- a/docs/superpowers/specs/2026-06-08-admin-individual-standup-design.md
+++ b/docs/superpowers/specs/2026-06-08-admin-individual-standup-design.md
@@ -76,8 +76,9 @@ In `previewStandup`, when `mentionedUserId` is present:
 
 In `postStandup`, when `mentionedUserId` is present:
 
-1. Steps 1–4 as preview (errors use the same response style as the existing team
-   post command).
+1. Steps 1–4 as preview. Unlike the team `/dd-standup-post`, **individual-post
+   errors are ephemeral** (only the admin needs to see "not a member" / "no
+   standup found"); the success confirmation is ephemeral too.
 2. Ensure the day's team `StandupPost` thread exists
    (`standupService.getStandupPost`). **If missing, auto-post the team summary**
    via `standupService.postTeamStandup(team, date, { client })` to create the

--- a/docs/superpowers/specs/2026-06-08-admin-individual-standup-design.md
+++ b/docs/superpowers/specs/2026-06-08-admin-individual-standup-design.md
@@ -1,0 +1,140 @@
+# Admin preview / post of an individual member's standup
+
+**Date:** 2026-06-08
+**Status:** Approved (design)
+
+## Summary
+
+Let an admin (org owner, org admin, or team admin) preview and post a **single
+team member's** standup, by extending the existing team-level
+`/dd-standup-preview` and `/dd-standup-post` commands with an optional Slack
+mention. Without a mention, both commands behave exactly as they do today.
+
+This covers two needs:
+
+- **Preview** one member's submission privately (ephemeral) before acting.
+- **Post** one member's submission into the day's team standup thread (e.g. a
+  late or manually-chased entry), appended as a threaded reply.
+
+## Commands (extended, backward compatible)
+
+| Command                                     | Without mention (unchanged)                 | With `@user` (new)                                         |
+| ------------------------------------------- | ------------------------------------------- | ---------------------------------------------------------- |
+| `/dd-standup-preview [@user] [date] [team]` | Ephemeral preview of the whole team summary | Ephemeral preview of just that member's standup            |
+| `/dd-standup-post [@user] [date] [team]`    | Post the team summary to the channel        | Append that member's standup as a reply in the team thread |
+
+Argument order is free-form (mention, date, and team name are each detected by
+pattern), matching the current parser's behavior.
+
+## Permission
+
+Reuse the shared `canManageTeam()` gate. **Broaden it to include org admins**:
+
+```
+canManage = org OWNER  ||  org ADMIN (new)  ||  team ADMIN
+```
+
+This is an intentional, repo-wide change: org admins gain management rights for
+**all** admin commands (team post/remind/preview/followup, leave admin paths,
+team update), not just this feature — consistent with treating `OrgRole.ADMIN`
+as a real admin. Today only `OWNER` + team admin are granted anywhere.
+
+- Add `isOrganizationAdmin(userId, organizationId)` to `permissionHelper.js`
+  (mirrors `isOrganizationOwner`, matching `role === "ADMIN"`).
+- In `canManageTeam`, grant management when the user is org owner **or** org
+  admin **or** team admin. Report the resolved role accordingly.
+
+## Argument parsing
+
+Extend `teamHelper.parseCommandArguments(commandText)` to also extract a Slack
+mention before team-name parsing:
+
+- Match `<@U…>` or `<@U…|name>` via `/<@([A-Z0-9]+)(?:\|[^>]+)?>/`.
+- Strip the matched mention from the text, then parse date and team name as
+  today.
+- Return `{ date, teamName, mentionedUserId }`. Existing callers ignore the new
+  field, so they are unaffected.
+- If multiple mentions are present, use the first and ignore the rest.
+
+## Individual preview flow
+
+In `previewStandup`, when `mentionedUserId` is present:
+
+1. Resolve requesting user, resolve team from context, check `canManageTeam`
+   (existing steps, ephemeral errors).
+2. Resolve the target user via `getUserBySlackId(mentionedUserId)`; verify they
+   are an **active `TeamMember`** of the resolved team — else ephemeral error
+   "That user isn't a member of <team>."
+3. Fetch the target's response for the date via
+   `standupService.getUserResponse(team.id, targetUser.id, targetDate)` (regular
+   or late).
+4. No response ⇒ ephemeral "No standup found for <@user> on <date>."
+5. Render an ephemeral preview: a short header (member + date) followed by
+   `blockHelper.createUserResponseBlocks(response)`.
+
+## Individual post flow
+
+In `postStandup`, when `mentionedUserId` is present:
+
+1. Steps 1–4 as preview (errors use the same response style as the existing team
+   post command).
+2. Ensure the day's team `StandupPost` thread exists
+   (`standupService.getStandupPost`). **If missing, auto-post the team summary**
+   via `standupService.postTeamStandup(team, date, { client })` to create the
+   thread, then re-fetch the post.
+3. Append the member's standup as a threaded reply (`thread_ts`,
+   `reply_broadcast: true`) using `createUserResponseBlocks(response)` — **no
+   "posted by admin" label**; it reads like a normal entry.
+4. **Always appends** — no dedup, even if the member already appears in the
+   summary or an earlier reply (mirrors how late responses already work). No
+   schema change.
+5. Ephemeral success confirmation to the admin (member, date, message ts).
+
+## New / changed code
+
+- `src/utils/permissionHelper.js` — add `isOrganizationAdmin`; broaden
+  `canManageTeam`; export the new helper.
+- `src/utils/teamHelper.js` — `parseCommandArguments` returns `mentionedUserId`.
+- `src/services/standupService.js`:
+  - `getUserResponse(teamId, userId, date)` — single member's response for the
+    date (either `isLate`).
+  - `postIndividualResponse(team, date, response, slackApp)` — ensure/auto-create
+    thread, then post the reply.
+- `src/commands/standup.js` — branch `previewStandup` and `postStandup` on
+  `mentionedUserId`.
+- `src/utils/blockHelper.js` — **no new builder**; reuse `createUserResponseBlocks`.
+  A thin individual-preview header may reuse `createSectionBlock`.
+
+## Testing
+
+- `teamHelper.parseCommandArguments`: mention extraction in combination with
+  date and team name, and mention-only; multiple mentions → first wins.
+- `permissionHelper.canManageTeam`: org admin now returns `canManage: true`;
+  org member still denied.
+- `standupService.postIndividualResponse` (mocked Slack client): auto-posts the
+  team summary when no thread exists, then replies; appends a reply when the
+  thread already exists.
+- (Covered already) `createUserResponseBlocks` stays within Slack field limits.
+
+## Documentation
+
+- `README.md` — document the `@user` form of both commands.
+- `CHANGELOG.md` — technical entry (always).
+- `web/src/data/changelog.json` — user-facing entry (admins can post/preview a
+  single member's standup; org admins now have admin access).
+- Help/usage text in `standup.js`.
+- Slack manifest: **unchanged** (same command names).
+
+## Edge cases
+
+- `@user` not a member of the team → clear error.
+- `@user` has no submission for the date → "no standup found".
+- Multiple mentions → first wins.
+- Admin posts their own standup → allowed.
+- No team standup posted yet (post flow) → auto-post summary, then reply.
+
+## Out of scope
+
+- Per-member message tracking / in-place edit of replies (we append).
+- Modal/user-picker UX (command + mention only).
+- A distinct standalone (non-threaded) post mode.

--- a/src/commands/standup.js
+++ b/src/commands/standup.js
@@ -782,7 +782,11 @@ async function postStandup({ command, ack, respond, client }) {
     }
 
     // Parse command arguments (date and/or team name)
-    const { date: dateStr, teamName } = parseCommandArguments(command.text);
+    const {
+      date: dateStr,
+      teamName,
+      mentionedUserId,
+    } = parseCommandArguments(command.text);
 
     // Validate date format if provided
     if (dateStr) {
@@ -827,6 +831,62 @@ async function postStandup({ command, ack, respond, client }) {
     const targetDate = dateStr
       ? dayjs(dateStr).tz(team.timezone)
       : dayjs().tz(team.timezone);
+
+    // Individual member post (ephemeral errors + confirmation)
+    if (mentionedUserId) {
+      const { targetUser, error: memberError } = await resolveTargetMember(
+        team.id,
+        mentionedUserId
+      );
+      if (memberError) {
+        await updateResponse({
+          blocks: createCommandErrorBlocks(memberError),
+          response_type: "ephemeral",
+        });
+        return;
+      }
+
+      const response = await standupService.getUserResponse(
+        team.id,
+        targetUser.id,
+        targetDate.toDate()
+      );
+      if (!response) {
+        await updateResponse({
+          blocks: createNoDataBlocks(
+            `standup from ${getUserMention(targetUser)}`,
+            targetDate.format("MMM DD, YYYY")
+          ),
+          response_type: "ephemeral",
+        });
+        return;
+      }
+
+      const result = await standupService.postIndividualResponse(
+        team,
+        targetDate.toDate(),
+        response,
+        { client }
+      );
+
+      await updateResponse({
+        blocks: createCommandSuccessBlocks(
+          `Posted ${getUserMention(targetUser)}'s standup to *${team.name}*`,
+          {
+            Date: targetDate.format("MMM DD, YYYY"),
+            "Message timestamp": result.ts,
+          }
+        ),
+        response_type: "ephemeral",
+      });
+
+      console.log(
+        `📊 ${getUserLogIdentifier(user)} posted ${getUserMention(
+          targetUser
+        )}'s standup for team ${team.name} (${targetDate.format("YYYY-MM-DD")})`
+      );
+      return;
+    }
 
     // Check if responses exist
     const responses = await standupService.getTeamResponses(

--- a/src/commands/standup.js
+++ b/src/commands/standup.js
@@ -894,6 +894,29 @@ async function postStandup({ command, ack, respond, client }) {
 }
 
 /**
+ * Resolve a mentioned Slack user to an active member of the given team.
+ * @param {string} teamId
+ * @param {string} mentionedUserId - Slack user ID from the command mention
+ * @returns {Promise<{targetUser?: object, error?: string}>}
+ */
+async function resolveTargetMember(teamId, mentionedUserId) {
+  const targetUser = await getUserBySlackId(mentionedUserId);
+  if (!targetUser) {
+    return { error: "That user isn't registered in the system." };
+  }
+
+  const membership = await prisma.teamMember.findUnique({
+    where: { teamId_userId: { teamId, userId: targetUser.id } },
+  });
+
+  if (!membership || !membership.isActive) {
+    return { error: "That user isn't an active member of this team." };
+  }
+
+  return { targetUser };
+}
+
+/**
  * Admin/Owner command: Preview standup summary
  * Usage: /dd-standup-preview [date] [team-name]
  */
@@ -919,7 +942,11 @@ async function previewStandup({ command, ack, respond }) {
     }
 
     // Parse command arguments
-    const { date: dateStr, teamName } = parseCommandArguments(command.text);
+    const {
+      date: dateStr,
+      teamName,
+      mentionedUserId,
+    } = parseCommandArguments(command.text);
 
     // Validate date format if provided
     if (dateStr) {
@@ -967,6 +994,59 @@ async function previewStandup({ command, ack, respond }) {
     const targetDate = dateStr
       ? dayjs(dateStr).tz(team.timezone)
       : dayjs().tz(team.timezone);
+
+    // Individual member preview
+    if (mentionedUserId) {
+      const { targetUser, error: memberError } = await resolveTargetMember(
+        team.id,
+        mentionedUserId
+      );
+      if (memberError) {
+        await updateResponse({
+          blocks: createCommandErrorBlocks(memberError),
+          response_type: "ephemeral",
+        });
+        return;
+      }
+
+      const response = await standupService.getUserResponse(
+        team.id,
+        targetUser.id,
+        targetDate.toDate()
+      );
+      if (!response) {
+        await updateResponse({
+          blocks: createNoDataBlocks(
+            `standup from ${getUserMention(targetUser)}`,
+            targetDate.format("MMM DD, YYYY")
+          ),
+          response_type: "ephemeral",
+        });
+        return;
+      }
+
+      const message =
+        await standupService.formatIndividualResponseMessage(response);
+
+      await updateResponse({
+        blocks: [
+          createSectionBlock(
+            `🔍 *Preview — ${getUserMention(targetUser)}'s standup* · ${targetDate.format(
+              "MMM DD, YYYY"
+            )}`
+          ),
+          ...message.blocks,
+        ],
+        response_type: "ephemeral",
+      });
+
+      console.log(
+        `🔍 ${getUserLogIdentifier(user)} previewed ${getUserMention(
+          targetUser
+        )}'s standup for team ${team.name} (${targetDate.format("YYYY-MM-DD")})`
+      );
+      return;
+    }
 
     // Get standup data
     const responses = await standupService.getTeamResponses(

--- a/src/services/standupService.js
+++ b/src/services/standupService.js
@@ -18,6 +18,7 @@ const {
   createTaskFieldBlocks,
   createDividerBlock,
   createLateResponseBlocks,
+  createUserResponseBlocks,
   createNotRespondedBlocks,
   createOnLeaveBlocks,
 } = require("../utils/blockHelper");
@@ -371,6 +372,20 @@ class StandupService {
     return {
       text: `Late Submission from ${getDisplayName(response.user)}`,
       blocks,
+    };
+  }
+
+  async formatIndividualResponseMessage(response) {
+    const responseData = {
+      userMention: getUserMention(response.user),
+      yesterdayTasks: formatTasks(response.yesterdayTasks),
+      todayTasks: formatTasks(response.todayTasks),
+      blockers: response.blockers,
+    };
+
+    return {
+      text: `Standup from ${getDisplayName(response.user)}`,
+      blocks: createUserResponseBlocks(responseData),
     };
   }
 

--- a/src/services/standupService.js
+++ b/src/services/standupService.js
@@ -700,6 +700,30 @@ class StandupService {
       throw error;
     }
   }
+
+  async postIndividualResponse(team, date, response, slackApp) {
+    // Ensure a team standup thread exists; auto-create it if missing.
+    let standupPost = await this.getStandupPost(team.id, date);
+    if (!standupPost || !standupPost.slackMessageTs) {
+      await this.postTeamStandup(team, date, slackApp);
+      standupPost = await this.getStandupPost(team.id, date);
+    }
+
+    if (!standupPost || !standupPost.slackMessageTs) {
+      throw new Error("Could not find or create a standup thread to post into");
+    }
+
+    const message = await this.formatIndividualResponseMessage(response);
+
+    const result = await slackApp.client.chat.postMessage({
+      channel: standupPost.channelId,
+      thread_ts: standupPost.slackMessageTs,
+      reply_broadcast: true,
+      ...message,
+    });
+
+    return { ts: result.ts, channel: standupPost.channelId };
+  }
 }
 
 module.exports = new StandupService();

--- a/src/services/standupService.js
+++ b/src/services/standupService.js
@@ -179,6 +179,7 @@ class StandupService {
       include: {
         user: true,
       },
+      // Most recent submission wins if the user re-submitted
       orderBy: {
         submittedAt: "desc",
       },
@@ -702,27 +703,43 @@ class StandupService {
   }
 
   async postIndividualResponse(team, date, response, slackApp) {
-    // Ensure a team standup thread exists; auto-create it if missing.
-    let standupPost = await this.getStandupPost(team.id, date);
-    if (!standupPost || !standupPost.slackMessageTs) {
-      await this.postTeamStandup(team, date, slackApp);
-      standupPost = await this.getStandupPost(team.id, date);
+    try {
+      // Ensure a team standup thread exists; auto-create it if missing.
+      let standupPost = await this.getStandupPost(team.id, date);
+      if (!standupPost || !standupPost.slackMessageTs) {
+        await this.postTeamStandup(team, date, slackApp);
+        standupPost = await this.getStandupPost(team.id, date);
+      }
+
+      if (!standupPost || !standupPost.slackMessageTs) {
+        throw new Error(
+          "Could not find or create a standup thread to post into"
+        );
+      }
+
+      const message = await this.formatIndividualResponseMessage(response);
+
+      const result = await slackApp.client.chat.postMessage({
+        channel: standupPost.channelId,
+        thread_ts: standupPost.slackMessageTs,
+        reply_broadcast: true,
+        ...message,
+      });
+
+      console.log(
+        `✅ Posted individual standup for ${getDisplayName(
+          response.user
+        )} in team ${team.name}`
+      );
+
+      return { ts: result.ts, channel: standupPost.channelId };
+    } catch (error) {
+      console.error(
+        `Failed to post individual standup for team ${team.name}:`,
+        error
+      );
+      throw error;
     }
-
-    if (!standupPost || !standupPost.slackMessageTs) {
-      throw new Error("Could not find or create a standup thread to post into");
-    }
-
-    const message = await this.formatIndividualResponseMessage(response);
-
-    const result = await slackApp.client.chat.postMessage({
-      channel: standupPost.channelId,
-      thread_ts: standupPost.slackMessageTs,
-      reply_broadcast: true,
-      ...message,
-    });
-
-    return { ts: result.ts, channel: standupPost.channelId };
   }
 }
 

--- a/src/services/standupService.js
+++ b/src/services/standupService.js
@@ -162,6 +162,28 @@ class StandupService {
     });
   }
 
+  async getUserResponse(teamId, userId, date) {
+    const startOfDay = dayjs(date).startOf("day").toDate();
+    const endOfDay = dayjs(date).endOf("day").toDate();
+
+    return await prisma.standupResponse.findFirst({
+      where: {
+        teamId,
+        userId,
+        standupDate: {
+          gte: startOfDay,
+          lte: endOfDay,
+        },
+      },
+      include: {
+        user: true,
+      },
+      orderBy: {
+        submittedAt: "desc",
+      },
+    });
+  }
+
   async saveStandupPost(teamId, date, messageTs, channelId) {
     const standupDate = dayjs(date).toDate();
 

--- a/src/utils/permissionHelper.js
+++ b/src/utils/permissionHelper.js
@@ -21,6 +21,26 @@ async function isOrganizationOwner(userId, organizationId) {
 }
 
 /**
+ * Check if a user is an admin of an organization
+ * @param {string} userId - The user ID to check
+ * @param {string} organizationId - The organization ID to check against
+ * @returns {Promise<boolean>} True if user is an organization admin
+ */
+async function isOrganizationAdmin(userId, organizationId) {
+  try {
+    const membership = await prisma.organizationMember.findUnique({
+      where: { organizationId_userId: { organizationId, userId } },
+      select: { role: true, isActive: true },
+    });
+
+    return !!membership && membership.isActive && membership.role === "ADMIN";
+  } catch (error) {
+    console.error("Error checking organization admin:", error);
+    return false;
+  }
+}
+
+/**
  * Check if a user is an admin of a specific team
  * @param {number} userId - The user ID to check
  * @param {number} teamId - The team ID to check against
@@ -76,6 +96,16 @@ async function canManageTeam(userId, teamId) {
       };
     }
 
+    // Check if user is an organization admin
+    const isOrgAdmin = await isOrganizationAdmin(userId, team.organizationId);
+    if (isOrgAdmin) {
+      return {
+        canManage: true,
+        role: "ORG_ADMIN",
+        reason: null,
+      };
+    }
+
     // Check if user is team admin
     const isAdmin = await isTeamAdmin(userId, teamId);
     if (isAdmin) {
@@ -121,6 +151,7 @@ async function getUserBySlackId(slackUserId) {
 
 module.exports = {
   isOrganizationOwner,
+  isOrganizationAdmin,
   isTeamAdmin,
   canManageTeam,
   getUserBySlackId,

--- a/src/utils/teamHelper.js
+++ b/src/utils/teamHelper.js
@@ -187,7 +187,7 @@ function parseTeamName(commandText) {
  * - "team name" 2025-01-15
  *
  * @param {string} commandText - The command text to parse
- * @returns {{date: string|null, teamName: string|null}} Parsed date and team name
+ * @returns {{date: string|null, teamName: string|null, mentionedUserId: string|null}} Parsed date, team name, and mentioned user ID
  */
 function parseCommandArguments(commandText) {
   if (!commandText || !commandText.trim()) {
@@ -199,12 +199,13 @@ function parseCommandArguments(commandText) {
   let teamName = null;
   let mentionedUserId = null;
 
-  // Mention pattern: <@U123> or <@U123|name>. Use the first, strip all.
+  // Mention pattern: <@U123> or <@U123|name>. Slack user IDs are uppercase
+  // alphanumeric. Use the first mention; strip all before date/team parsing.
   const mentionPattern = /<@([A-Z0-9]+)(?:\|[^>]+)?>/g;
-  const mentionMatch = text.match(mentionPattern);
-  if (mentionMatch) {
-    const first = /<@([A-Z0-9]+)(?:\|[^>]+)?>/.exec(mentionMatch[0]);
-    mentionedUserId = first[1];
+  const firstMention = mentionPattern.exec(text);
+  if (firstMention) {
+    mentionedUserId = firstMention[1];
+    mentionPattern.lastIndex = 0; // reset stateful /g regex before reuse
     text = text.replace(mentionPattern, "").trim();
   }
 

--- a/src/utils/teamHelper.js
+++ b/src/utils/teamHelper.js
@@ -191,12 +191,22 @@ function parseTeamName(commandText) {
  */
 function parseCommandArguments(commandText) {
   if (!commandText || !commandText.trim()) {
-    return { date: null, teamName: null };
+    return { date: null, teamName: null, mentionedUserId: null };
   }
 
-  const text = commandText.trim();
+  let text = commandText.trim();
   let date = null;
   let teamName = null;
+  let mentionedUserId = null;
+
+  // Mention pattern: <@U123> or <@U123|name>. Use the first, strip all.
+  const mentionPattern = /<@([A-Z0-9]+)(?:\|[^>]+)?>/g;
+  const mentionMatch = text.match(mentionPattern);
+  if (mentionMatch) {
+    const first = /<@([A-Z0-9]+)(?:\|[^>]+)?>/.exec(mentionMatch[0]);
+    mentionedUserId = first[1];
+    text = text.replace(mentionPattern, "").trim();
+  }
 
   // Date pattern: YYYY-MM-DD
   const datePattern = /\b(\d{4}-\d{2}-\d{2})\b/;
@@ -204,17 +214,15 @@ function parseCommandArguments(commandText) {
 
   if (dateMatch) {
     date = dateMatch[1];
-    // Remove date from text to extract team name
     const remainingText = text.replace(dateMatch[0], "").trim();
     if (remainingText) {
       teamName = parseTeamName(remainingText);
     }
-  } else {
-    // No date, entire text is team name
+  } else if (text) {
     teamName = parseTeamName(text);
   }
 
-  return { date, teamName };
+  return { date, teamName, mentionedUserId };
 }
 
 /**

--- a/test/services/standupServiceIndividual.test.js
+++ b/test/services/standupServiceIndividual.test.js
@@ -1,0 +1,127 @@
+jest.mock("../../src/config/prisma", () => ({
+  standupResponse: { findFirst: jest.fn(), findMany: jest.fn() },
+  standupPost: { findUnique: jest.fn(), upsert: jest.fn() },
+  team: { findUnique: jest.fn() },
+  teamMember: { findMany: jest.fn() },
+  holiday: { findMany: jest.fn() },
+  user: { findUnique: jest.fn() },
+  organization: { findUnique: jest.fn() },
+}));
+
+const prisma = require("../../src/config/prisma");
+const standupService = require("../../src/services/standupService");
+
+describe("getUserResponse", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("queries the member's response for the date window", async () => {
+    const row = { id: "r1", user: { slackUserId: "U1" } };
+    prisma.standupResponse.findFirst.mockResolvedValue(row);
+
+    const result = await standupService.getUserResponse(
+      "t1",
+      "u1",
+      new Date("2025-01-15T10:00:00Z")
+    );
+
+    expect(result).toBe(row);
+    const arg = prisma.standupResponse.findFirst.mock.calls[0][0];
+    expect(arg.where.teamId).toBe("t1");
+    expect(arg.where.userId).toBe("u1");
+    expect(arg.where.standupDate.gte).toBeInstanceOf(Date);
+    expect(arg.where.standupDate.lte).toBeInstanceOf(Date);
+    expect(arg.include).toEqual({ user: true });
+  });
+
+  it("returns null when there is no response", async () => {
+    prisma.standupResponse.findFirst.mockResolvedValue(null);
+    const result = await standupService.getUserResponse("t1", "u1", new Date());
+    expect(result).toBeNull();
+  });
+});
+
+describe("formatIndividualResponseMessage", () => {
+  it("returns text and blocks with the member section, no admin label", async () => {
+    const response = {
+      user: { slackUserId: "U1", name: "Alice" },
+      yesterdayTasks: "shipped X",
+      todayTasks: "review Y",
+      blockers: null,
+    };
+
+    const msg = await standupService.formatIndividualResponseMessage(response);
+
+    expect(typeof msg.text).toBe("string");
+    expect(Array.isArray(msg.blocks)).toBe(true);
+    // First block is the member header section "*👤 <@U1>*"
+    expect(msg.blocks[0].text.text).toContain("<@U1>");
+    // No "Late Submission" / "posted by admin" labelling anywhere
+    const serialized = JSON.stringify(msg.blocks);
+    expect(serialized).not.toContain("Late Submission");
+    expect(serialized.toLowerCase()).not.toContain("posted by admin");
+  });
+});
+
+describe("postIndividualResponse", () => {
+  const team = { id: "t1", name: "Eng", slackChannelId: "C1" };
+  const response = {
+    user: { slackUserId: "U1", name: "Alice" },
+    yesterdayTasks: "a",
+    todayTasks: "b",
+    blockers: null,
+  };
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it("appends a threaded reply when a thread already exists", async () => {
+    jest
+      .spyOn(standupService, "getStandupPost")
+      .mockResolvedValue({ slackMessageTs: "111.1", channelId: "C1" });
+    const postTeam = jest
+      .spyOn(standupService, "postTeamStandup")
+      .mockResolvedValue({});
+    const postMessage = jest.fn().mockResolvedValue({ ts: "222.2" });
+    const slackApp = { client: { chat: { postMessage } } };
+
+    const result = await standupService.postIndividualResponse(
+      team,
+      new Date("2025-01-15"),
+      response,
+      slackApp
+    );
+
+    expect(postTeam).not.toHaveBeenCalled();
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C1",
+        thread_ts: "111.1",
+        reply_broadcast: true,
+      })
+    );
+    expect(result).toMatchObject({ ts: "222.2", channel: "C1" });
+  });
+
+  it("auto-posts the team summary first when no thread exists", async () => {
+    jest
+      .spyOn(standupService, "getStandupPost")
+      .mockResolvedValueOnce(null) // before
+      .mockResolvedValueOnce({ slackMessageTs: "333.3", channelId: "C1" }); // after
+    const postTeam = jest
+      .spyOn(standupService, "postTeamStandup")
+      .mockResolvedValue({});
+    const postMessage = jest.fn().mockResolvedValue({ ts: "444.4" });
+    const slackApp = { client: { chat: { postMessage } } };
+
+    await standupService.postIndividualResponse(
+      team,
+      new Date("2025-01-15"),
+      response,
+      slackApp
+    );
+
+    expect(postTeam).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ thread_ts: "333.3", reply_broadcast: true })
+    );
+  });
+});

--- a/test/services/standupServiceIndividual.test.js
+++ b/test/services/standupServiceIndividual.test.js
@@ -52,6 +52,7 @@ describe("formatIndividualResponseMessage", () => {
     const msg = await standupService.formatIndividualResponseMessage(response);
 
     expect(typeof msg.text).toBe("string");
+    expect(msg.text).toContain("Alice");
     expect(Array.isArray(msg.blocks)).toBe(true);
     // First block is the member header section "*👤 <@U1>*"
     expect(msg.blocks[0].text.text).toContain("<@U1>");
@@ -123,5 +124,22 @@ describe("postIndividualResponse", () => {
     expect(postMessage).toHaveBeenCalledWith(
       expect.objectContaining({ thread_ts: "333.3", reply_broadcast: true })
     );
+  });
+
+  it("throws when no thread can be found or created", async () => {
+    jest.spyOn(standupService, "getStandupPost").mockResolvedValue(null);
+    jest.spyOn(standupService, "postTeamStandup").mockResolvedValue({});
+    const postMessage = jest.fn();
+    const slackApp = { client: { chat: { postMessage } } };
+
+    await expect(
+      standupService.postIndividualResponse(
+        team,
+        new Date("2025-01-15"),
+        response,
+        slackApp
+      )
+    ).rejects.toThrow();
+    expect(postMessage).not.toHaveBeenCalled();
   });
 });

--- a/test/utils/permissionHelper.test.js
+++ b/test/utils/permissionHelper.test.js
@@ -18,10 +18,9 @@ describe("canManageTeam org admin access", () => {
     prisma.team.findFirst.mockResolvedValue({ organizationId: "o1" });
     // Both the owner check and the admin check call findUnique; ADMIN role
     // fails the owner check (role !== OWNER) and passes the admin check.
-    prisma.organizationMember.findUnique.mockResolvedValue({
-      role: "ADMIN",
-      isActive: true,
-    });
+    prisma.organizationMember.findUnique
+      .mockResolvedValueOnce({ role: "ADMIN", isActive: true }) // owner check → false
+      .mockResolvedValueOnce({ role: "ADMIN", isActive: true }); // admin check → true
     prisma.teamMember.findFirst.mockResolvedValue(null);
 
     const res = await canManageTeam("u1", "t1");
@@ -45,6 +44,11 @@ describe("canManageTeam org admin access", () => {
       role: "ADMIN",
       isActive: false,
     });
+    expect(await isOrganizationAdmin("u1", "o1")).toBe(false);
+  });
+
+  it("isOrganizationAdmin is false when not a member", async () => {
+    prisma.organizationMember.findUnique.mockResolvedValue(null);
     expect(await isOrganizationAdmin("u1", "o1")).toBe(false);
   });
 });

--- a/test/utils/permissionHelper.test.js
+++ b/test/utils/permissionHelper.test.js
@@ -1,0 +1,50 @@
+jest.mock("../../src/config/prisma", () => ({
+  team: { findFirst: jest.fn() },
+  organizationMember: { findUnique: jest.fn() },
+  teamMember: { findFirst: jest.fn() },
+  user: { findUnique: jest.fn() },
+}));
+
+const prisma = require("../../src/config/prisma");
+const {
+  canManageTeam,
+  isOrganizationAdmin,
+} = require("../../src/utils/permissionHelper");
+
+describe("canManageTeam org admin access", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("grants management to an active org admin", async () => {
+    prisma.team.findFirst.mockResolvedValue({ organizationId: "o1" });
+    // Both the owner check and the admin check call findUnique; ADMIN role
+    // fails the owner check (role !== OWNER) and passes the admin check.
+    prisma.organizationMember.findUnique.mockResolvedValue({
+      role: "ADMIN",
+      isActive: true,
+    });
+    prisma.teamMember.findFirst.mockResolvedValue(null);
+
+    const res = await canManageTeam("u1", "t1");
+    expect(res).toMatchObject({ canManage: true, role: "ORG_ADMIN" });
+  });
+
+  it("denies a plain org member who is not a team admin", async () => {
+    prisma.team.findFirst.mockResolvedValue({ organizationId: "o1" });
+    prisma.organizationMember.findUnique.mockResolvedValue({
+      role: "MEMBER",
+      isActive: true,
+    });
+    prisma.teamMember.findFirst.mockResolvedValue(null);
+
+    const res = await canManageTeam("u1", "t1");
+    expect(res.canManage).toBe(false);
+  });
+
+  it("isOrganizationAdmin is false for an inactive admin", async () => {
+    prisma.organizationMember.findUnique.mockResolvedValue({
+      role: "ADMIN",
+      isActive: false,
+    });
+    expect(await isOrganizationAdmin("u1", "o1")).toBe(false);
+  });
+});

--- a/test/utils/teamHelper.test.js
+++ b/test/utils/teamHelper.test.js
@@ -41,4 +41,18 @@ describe("parseCommandArguments mention extraction", () => {
       mentionedUserId: null,
     });
   });
+
+  it("parses team name when the mention is in the middle", () => {
+    const res = parseCommandArguments("Engineering <@U123|alice> 2025-01-15");
+    expect(res).toEqual({
+      date: "2025-01-15",
+      teamName: "Engineering",
+      mentionedUserId: "U123",
+    });
+  });
+
+  it("does not match a lowercase user id", () => {
+    const res = parseCommandArguments("<@u123abc>");
+    expect(res.mentionedUserId).toBeNull();
+  });
 });

--- a/test/utils/teamHelper.test.js
+++ b/test/utils/teamHelper.test.js
@@ -1,0 +1,44 @@
+const { parseCommandArguments } = require("../../src/utils/teamHelper");
+
+describe("parseCommandArguments mention extraction", () => {
+  it("returns null mentionedUserId when no mention present", () => {
+    expect(parseCommandArguments("2025-01-15 Engineering")).toEqual({
+      date: "2025-01-15",
+      teamName: "Engineering",
+      mentionedUserId: null,
+    });
+  });
+
+  it("extracts a mention with a pipe label and keeps date + team", () => {
+    const res = parseCommandArguments(
+      "<@U123ABC|alice> 2025-01-15 Engineering"
+    );
+    expect(res).toEqual({
+      date: "2025-01-15",
+      teamName: "Engineering",
+      mentionedUserId: "U123ABC",
+    });
+  });
+
+  it("extracts a bare mention with no label", () => {
+    const res = parseCommandArguments("<@U999>");
+    expect(res).toEqual({
+      date: null,
+      teamName: null,
+      mentionedUserId: "U999",
+    });
+  });
+
+  it("uses the first mention when several are present", () => {
+    const res = parseCommandArguments("<@U111|a> <@U222|b>");
+    expect(res.mentionedUserId).toBe("U111");
+  });
+
+  it("returns all-null for empty input", () => {
+    expect(parseCommandArguments("")).toEqual({
+      date: null,
+      teamName: null,
+      mentionedUserId: null,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds the ability for admins to **preview and post a single team member's standup** by adding an optional `@mention` to the existing `/dd-standup-preview` and `/dd-standup-post` commands. Without a mention, both commands behave exactly as before.

- **Preview** (`/dd-standup-preview @user [date] [team]`) — ephemeral preview of just that member's standup.
- **Post** (`/dd-standup-post @user [date] [team]`) — appends the member's standup as a threaded reply under the day's team standup post (`reply_broadcast: true`). If no team standup exists yet for the date, the team summary is auto-posted first to create the thread. Always appends — no dedup.
- **Org admins** (`OrgRole.ADMIN`) now have admin access to all admin commands, alongside org owners and team admins (`canManageTeam` broadened).

Built with the late-submission threading mechanics; reuses `blockHelper.createUserResponseBlocks` (no "admin-posted" label). No schema changes.

## Changes

- `permissionHelper.js` — new `isOrganizationAdmin`; `canManageTeam` grants org admins (`role: "ORG_ADMIN"`).
- `teamHelper.parseCommandArguments` — now returns `mentionedUserId` (first Slack mention; backward compatible).
- `standupService.js` — new `getUserResponse`, `formatIndividualResponseMessage`, `postIndividualResponse` (auto-creates thread, error handling + logging).
- `standup.js` — shared `resolveTargetMember` helper + individual branches in `previewStandup` and `postStandup` (ephemeral errors/confirmations).
- Docs: README + `CHANGELOG.md` (`[Unreleased]`).

Design & plan: `docs/superpowers/specs/2026-06-08-admin-individual-standup-design.md`, `docs/superpowers/plans/2026-06-08-admin-individual-standup.md`.

## Test Plan

Automated (77/77 pass, lint clean):
- [x] `permissionHelper` — org admin granted; plain member denied; inactive/non-member false.
- [x] `parseCommandArguments` — mention extraction (with/without date+team, bare, first-of-many, mid-text, lowercase rejected).
- [x] `standupService` — `getUserResponse` query/null; `formatIndividualResponseMessage` (no label, includes name); `postIndividualResponse` (appends when thread exists; auto-posts summary when absent; throws when none can be created).

Manual Slack verification (recommended before merge):
- [ ] `/dd-standup-preview @member` → ephemeral single-member preview.
- [ ] `/dd-standup-post @member` with an existing team thread → threaded reply appended.
- [ ] `/dd-standup-post @member` with NO team thread yet → team summary posted first, then reply.
- [ ] `/dd-standup-post @nonMember` / `@memberWithNoSubmission` → ephemeral errors.
- [ ] No-mention forms unchanged.
- [ ] As an org **admin** (not owner/team-admin): commands permitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `/dd-standup-preview` and `/dd-standup-post` commands now accept an optional `@mention` to preview/post an individual team member's standup
  * Organization admins can now manage teams

* **Documentation**
  * Updated command guides, changelog, and specification documents to reflect new standup command parameters and permission changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->