### PR TITLE
Let non-org-members create teams via an admin approval flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Self-service team creation with org-admin approval: anyone in the workspace can now run `/dd-team-create`, even if they aren't yet an organization member. Non-members are auto-onboarded into the workspace's organization as a `MEMBER` (mirroring `joinTeam`'s behavior) by resolving the org from the slash command's `team_id` (`Organization.slackWorkspaceId`). Teams created by org owners/admins go live immediately; teams created by regular members are created with `status = PENDING` and are not scheduled until approved. Org owners/admins receive a DM with Approve/Reject buttons; approval flips the team to `ACTIVE` and schedules it, rejection deletes the team (freeing the channel). The creator is DM'd the decision. (`src/services/teamService.js` — `createTeam` now takes `slackWorkspaceId` and returns `{ team, status, organization, creatorSlackUserId }`, plus new `getPendingTeamForDecision`/`approveTeam`/`rejectTeam`; `src/services/userService.js` — new `getOrganizationByWorkspaceId`/`getOrganizationAdmins`; `src/services/notificationService.js` — new `notifyOrgAdminsOfPendingTeam`; `src/commands/team.js` — `createTeam` handler + `approveTeam`/`rejectTeam` action handlers; `src/commands/index.js` — `approve_team_*`/`reject_team_*` action routes; `src/utils/blockHelper.js` — `createTeamApprovalRequestBlocks`/`createTeamApprovalResultBlocks`)
+
+### Changed
+
+- New `TeamStatus` enum (`PENDING`/`ACTIVE`/`REJECTED`) and `Team.status` column (default `ACTIVE`, so existing teams stay active). Migration `20260616131600_team_status`. (`prisma/schema.prisma`, `prisma/migrations/`)
+- `getActiveTeamsForScheduling` now filters `status = ACTIVE`, so pending teams never trigger reminders or posting until approved. (`src/services/teamService.js`)
+
+### Tests
+
+- `test/services/teamServiceApproval.test.js` covers auto-onboarding, pending vs. active creation, the no-org-for-workspace error, duplicate-channel guard, and approve/reject permission + state transitions.
+
 ## [1.11.0] - 2026-06-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ When you first interact with the bot, you'll be automatically added to your orga
 /dd-team-leave Engineering            # Leave specific team by name
 /dd-team-members                      # View members of team in current channel
 /dd-team-members Engineering          # View members of specific team
-/dd-team-create 09:30 10:00           # Create new team (uses channel name) ⚠️ (admin only)
-/dd-team-create MyTeam 09:30 10:00    # Create new team with custom name ⚠️ (admin only)
+/dd-team-create 09:30 10:00           # Create new team (uses channel name) — members' teams need admin approval
+/dd-team-create MyTeam 09:30 10:00    # Create new team with custom name — members' teams need admin approval
 /dd-team-update standup=09:00         # Update team in current channel ⚠️ (admin only)
 /dd-team-update Engineering standup=09:00  # Update specific team ⚠️ (admin only)
 /dd-team-suspend @user                # Suspend member from team in current channel ⚠️ (admin only)

--- a/README.md
+++ b/README.md
@@ -395,10 +395,11 @@ These commands allow team admins and organization owners to manually trigger sta
 - `/dd-team-members [team-name]` - View team members
   - **Channel-based**: `/dd-team-members` (shows members of team in current channel)
   - **Name-based**: `/dd-team-members Engineering` (shows members of specific team from any channel)
-- `/dd-team-create [team-name] <standup-time> <posting-time>` - Create a new team ⚠️ **(admin only)**
+- `/dd-team-create [team-name] <standup-time> <posting-time>` - Create a new team
   - **Channel-based**: `/dd-team-create 09:30 10:00` (uses channel name as team name)
   - **Custom name**: `/dd-team-create Engineering 09:30 10:00` (creates team with custom name)
-  - Requires admin permissions
+  - **Anyone in the workspace can create a team.** If you're not yet in the organization, you're added automatically as a member.
+  - Teams created by **org owners/admins** go live immediately. Teams created by **regular members** stay **pending** until an org admin approves them — admins receive an Approve/Reject prompt by DM, and you're notified of their decision.
 - `/dd-team-update [team-name] [parameters]` - Update team settings ⚠️ **(admin only)**
   - **Channel-based**: `/dd-team-update standup=09:00 posting=10:30` (updates team in current channel)
   - **Name-based**: `/dd-team-update Engineering standup=09:00 posting=10:30 notifications=false` (updates specific team from any channel)
@@ -512,6 +513,8 @@ The bot posts a formatted summary showing:
 3. Team members can join using:
    - **Channel-based**: `/dd-team-join` (joins team in current channel)
    - **Name-based**: `/dd-team-join Engineering` (joins specific team from any channel)
+
+> **Who can create a team?** Anyone in the workspace. A non-member who creates a team is automatically added to the organization. Teams created by org owners/admins are active right away; teams created by regular members are submitted for approval and become active once an org admin clicks **Approve** on the DM they receive (they can also **Reject**, which discards the request). The creator becomes the team admin once approved.
 
 ### Time Configuration
 
@@ -978,8 +981,10 @@ Team admins can manage leave for any member in their teams. This is useful for:
 
 **Can't create a team?**
 
-- You need admin permissions in your organization
-- Contact your organization admin
+- Anyone in the workspace can run `/dd-team-create` — if you're not in the organization yet, you're added automatically.
+- If you're a regular member, your team is submitted for approval; an org admin must Approve it before standups begin. Check with your org admin if it's still pending.
+- If you see "this Slack workspace isn't set up with Daily Dose yet," ask an org admin to set up the organization first.
+- A channel can only have one team — if the channel already has one (including a pending request), creation is blocked.
 
 **Standup not posting to channel?**
 

--- a/prisma/migrations/20260616131600_team_status/migration.sql
+++ b/prisma/migrations/20260616131600_team_status/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "public"."TeamStatus" AS ENUM ('PENDING', 'ACTIVE', 'REJECTED');
+
+-- AlterTable
+ALTER TABLE "public"."teams" ADD COLUMN     "status" "public"."TeamStatus" NOT NULL DEFAULT 'ACTIVE';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,6 +34,7 @@ model Team {
   postingTime      String            @map("posting_time")
   timezone         String            @default("America/New_York")
   isActive         Boolean           @default(true) @map("is_active")
+  status           TeamStatus        @default(ACTIVE) @map("status")
   createdAt        DateTime          @default(now()) @map("created_at")
   updatedAt        DateTime          @updatedAt @map("updated_at")
   standupPosts     StandupPost[]
@@ -197,4 +198,10 @@ enum OrgRole {
 enum TeamRole {
   ADMIN
   MEMBER
+}
+
+enum TeamStatus {
+  PENDING
+  ACTIVE
+  REJECTED
 }

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -107,6 +107,8 @@ function setupCommands(app) {
 
   // Interactive components (no formatting removal needed for these)
   app.action(/open_standup_.*/, standupCommands.openStandupModal);
+  app.action(/approve_team_.*/, teamCommands.approveTeam);
+  app.action(/reject_team_.*/, teamCommands.rejectTeam);
   app.view("standup_modal", standupCommands.handleStandupSubmission);
   app.view(
     "standup_update_modal",

--- a/src/commands/team.js
+++ b/src/commands/team.js
@@ -12,6 +12,7 @@ const {
 } = require("../utils/blockHelper");
 const logger = require("../utils/logger");
 const { parseTimeString } = require("../utils/timeHelper");
+const { escapeSlackText } = require("../utils/messageHelper");
 const { sanitizeError } = require("../utils/errorHelper");
 
 function parseUserMention(token) {
@@ -137,7 +138,7 @@ async function createTeam({ command, ack, respond, client }) {
       });
 
       await updateResponse({
-        text: `⏳ Team "${name}" has been submitted for approval.\n- Standup reminder: ${formatTime12Hour(
+        text: `⏳ Team "${escapeSlackText(name)}" has been submitted for approval.\n- Standup reminder: ${formatTime12Hour(
           parsedStandup.normalized
         )}\n- Posting time: ${formatTime12Hour(parsedPosting.normalized)}\n- Timezone: ${
           team.timezone
@@ -150,7 +151,7 @@ async function createTeam({ command, ack, respond, client }) {
     await schedulerService.refreshTeamSchedule(team.id);
 
     await updateResponse({
-      text: `✅ Team "${name}" created successfully!\n- Standup reminder: ${formatTime12Hour(
+      text: `✅ Team "${escapeSlackText(name)}" created successfully!\n- Standup reminder: ${formatTime12Hour(
         parsedStandup.normalized
       )}\n- Posting time: ${formatTime12Hour(parsedPosting.normalized)}\n- Timezone: ${
         team.timezone
@@ -831,26 +832,41 @@ async function approveTeam({ body, ack, client, respond }) {
 
   const teamId = body.actions[0].value;
 
+  // Phase 1: the state change. Failures here mean nothing was mutated, so we
+  // surface them to the admin.
+  let team, creatorSlackUserId;
   try {
-    const { team, creatorSlackUserId } = await teamService.approveTeam(
+    ({ team, creatorSlackUserId } = await teamService.approveTeam(
       body.user.id,
       teamId,
       client
-    );
+    ));
+  } catch (error) {
+    logger.error("Error approving team:", error);
+    await respond({
+      response_type: "ephemeral",
+      replace_original: false,
+      text: `⚠️ ${sanitizeError(error)}`,
+    });
+    return;
+  }
 
+  // Phase 2: best-effort Slack side effects. The approval already succeeded, so
+  // log failures here instead of reporting the whole action as failed.
+  try {
     await schedulerService.refreshTeamSchedule(team.id);
 
     if (creatorSlackUserId) {
       await client.chat.postMessage({
         channel: creatorSlackUserId,
-        text: `✅ Your team "${team.name}" was approved by <@${body.user.id}> and standups are now scheduled.`,
+        text: `✅ Your team "${escapeSlackText(team.name)}" was approved by <@${body.user.id}> and standups are now scheduled.`,
       });
     }
 
     await client.chat.update({
       channel: body.channel.id,
       ts: body.message.ts,
-      text: `Approved team "${team.name}"`,
+      text: `Approved team "${escapeSlackText(team.name)}"`,
       blocks: createTeamApprovalResultBlocks({
         teamName: team.name,
         channelId: team.slackChannelId,
@@ -859,12 +875,7 @@ async function approveTeam({ body, ack, client, respond }) {
       }),
     });
   } catch (error) {
-    logger.error("Error approving team:", error);
-    await respond({
-      response_type: "ephemeral",
-      replace_original: false,
-      text: `⚠️ ${sanitizeError(error)}`,
-    });
+    logger.error("Team approved but a follow-up Slack action failed:", error);
   }
 }
 
@@ -875,24 +886,39 @@ async function rejectTeam({ body, ack, client, respond }) {
 
   const teamId = body.actions[0].value;
 
+  // Phase 1: the state change. Failures here mean nothing was deleted, so we
+  // surface them to the admin.
+  let team, creatorSlackUserId;
   try {
-    const { team, creatorSlackUserId } = await teamService.rejectTeam(
+    ({ team, creatorSlackUserId } = await teamService.rejectTeam(
       body.user.id,
       teamId,
       client
-    );
+    ));
+  } catch (error) {
+    logger.error("Error rejecting team:", error);
+    await respond({
+      response_type: "ephemeral",
+      replace_original: false,
+      text: `⚠️ ${sanitizeError(error)}`,
+    });
+    return;
+  }
 
+  // Phase 2: best-effort Slack side effects. The rejection already succeeded, so
+  // log failures here instead of reporting the whole action as failed.
+  try {
     if (creatorSlackUserId) {
       await client.chat.postMessage({
         channel: creatorSlackUserId,
-        text: `❌ Your team "${team.name}" request was declined by <@${body.user.id}>. Reach out to an organization admin if you have questions.`,
+        text: `❌ Your team "${escapeSlackText(team.name)}" request was declined by <@${body.user.id}>. Reach out to an organization admin if you have questions.`,
       });
     }
 
     await client.chat.update({
       channel: body.channel.id,
       ts: body.message.ts,
-      text: `Rejected team "${team.name}"`,
+      text: `Rejected team "${escapeSlackText(team.name)}"`,
       blocks: createTeamApprovalResultBlocks({
         teamName: team.name,
         channelId: team.slackChannelId,
@@ -901,12 +927,7 @@ async function rejectTeam({ body, ack, client, respond }) {
       }),
     });
   } catch (error) {
-    logger.error("Error rejecting team:", error);
-    await respond({
-      response_type: "ephemeral",
-      replace_original: false,
-      text: `⚠️ ${sanitizeError(error)}`,
-    });
+    logger.error("Team rejected but a follow-up Slack action failed:", error);
   }
 }
 

--- a/src/commands/team.js
+++ b/src/commands/team.js
@@ -1,13 +1,16 @@
 const teamService = require("../services/teamService");
 const userService = require("../services/userService");
 const schedulerService = require("../services/schedulerService");
+const notificationService = require("../services/notificationService");
 const { ackWithProcessing, getChannelName } = require("../utils/commandHelper");
 const { getDisplayName } = require("../utils/userHelper");
 const { formatTime12Hour } = require("../utils/dateHelper");
 const {
   createSectionBlock,
   createCommandErrorBlocks,
+  createTeamApprovalResultBlocks,
 } = require("../utils/blockHelper");
+const logger = require("../utils/logger");
 const { parseTimeString } = require("../utils/timeHelper");
 const { sanitizeError } = require("../utils/errorHelper");
 
@@ -112,7 +115,7 @@ async function createTeam({ command, ack, respond, client }) {
       return;
     }
 
-    const team = await teamService.createTeam(
+    const { team, status, organization } = await teamService.createTeam(
       command.user_id,
       command.channel_id,
       {
@@ -120,8 +123,28 @@ async function createTeam({ command, ack, respond, client }) {
         standupTime: parsedStandup.normalized,
         postingTime: parsedPosting.normalized,
       },
+      command.team_id,
       client
     );
+
+    if (status === "PENDING") {
+      // Non-admin proposal: leave it unscheduled and ask org admins to approve.
+      await notificationService.notifyOrgAdminsOfPendingTeam({
+        team,
+        organization,
+        creatorSlackUserId: command.user_id,
+        client,
+      });
+
+      await updateResponse({
+        text: `⏳ Team "${name}" has been submitted for approval.\n- Standup reminder: ${formatTime12Hour(
+          parsedStandup.normalized
+        )}\n- Posting time: ${formatTime12Hour(parsedPosting.normalized)}\n- Timezone: ${
+          team.timezone
+        }\nAn organization admin will review it shortly — standups start once it's approved.`,
+      });
+      return;
+    }
 
     // Refresh the scheduler to include the new team
     await schedulerService.refreshTeamSchedule(team.id);
@@ -801,8 +824,96 @@ async function promoteOrgMember({ command, ack, respond, client }) {
   }
 }
 
+// Org admin clicks "Approve" on a pending-team request DM. Activates the team,
+// schedules it, notifies the proposer, and replaces the request buttons.
+async function approveTeam({ body, ack, client, respond }) {
+  await ack();
+
+  const teamId = body.actions[0].value;
+
+  try {
+    const { team, creatorSlackUserId } = await teamService.approveTeam(
+      body.user.id,
+      teamId,
+      client
+    );
+
+    await schedulerService.refreshTeamSchedule(team.id);
+
+    if (creatorSlackUserId) {
+      await client.chat.postMessage({
+        channel: creatorSlackUserId,
+        text: `✅ Your team "${team.name}" was approved by <@${body.user.id}> and standups are now scheduled.`,
+      });
+    }
+
+    await client.chat.update({
+      channel: body.channel.id,
+      ts: body.message.ts,
+      text: `Approved team "${team.name}"`,
+      blocks: createTeamApprovalResultBlocks({
+        teamName: team.name,
+        channelId: team.slackChannelId,
+        decidedBySlackUserId: body.user.id,
+        approved: true,
+      }),
+    });
+  } catch (error) {
+    logger.error("Error approving team:", error);
+    await respond({
+      response_type: "ephemeral",
+      replace_original: false,
+      text: `⚠️ ${sanitizeError(error)}`,
+    });
+  }
+}
+
+// Org admin clicks "Reject" on a pending-team request DM. Deletes the proposed
+// team, notifies the proposer, and replaces the request buttons.
+async function rejectTeam({ body, ack, client, respond }) {
+  await ack();
+
+  const teamId = body.actions[0].value;
+
+  try {
+    const { team, creatorSlackUserId } = await teamService.rejectTeam(
+      body.user.id,
+      teamId,
+      client
+    );
+
+    if (creatorSlackUserId) {
+      await client.chat.postMessage({
+        channel: creatorSlackUserId,
+        text: `❌ Your team "${team.name}" request was declined by <@${body.user.id}>. Reach out to an organization admin if you have questions.`,
+      });
+    }
+
+    await client.chat.update({
+      channel: body.channel.id,
+      ts: body.message.ts,
+      text: `Rejected team "${team.name}"`,
+      blocks: createTeamApprovalResultBlocks({
+        teamName: team.name,
+        channelId: team.slackChannelId,
+        decidedBySlackUserId: body.user.id,
+        approved: false,
+      }),
+    });
+  } catch (error) {
+    logger.error("Error rejecting team:", error);
+    await respond({
+      response_type: "ephemeral",
+      replace_original: false,
+      text: `⚠️ ${sanitizeError(error)}`,
+    });
+  }
+}
+
 module.exports = {
   createTeam,
+  approveTeam,
+  rejectTeam,
   joinTeam,
   leaveTeam,
   listTeams,

--- a/src/services/notificationService.js
+++ b/src/services/notificationService.js
@@ -1,7 +1,9 @@
 const teamService = require("./teamService");
+const userService = require("./userService");
 const logger = require("../utils/logger");
 const {
   createAdminSubmissionNotificationBlocks,
+  createTeamApprovalRequestBlocks,
 } = require("../utils/blockHelper");
 
 class NotificationService {
@@ -126,6 +128,47 @@ class NotificationService {
     } catch (error) {
       logger.error("Error notifying team admins:", error);
       // Don't throw here - original operation should not be affected by notification failures
+    }
+  }
+
+  /**
+   * DM every org admin/owner to ask them to approve or reject a team proposed
+   * by a non-admin member. The proposer is skipped if they happen to be an
+   * admin (they aren't, in practice, since admins create active teams).
+   * @param {Object} params
+   * @param {Object} params.team - The pending team record
+   * @param {Object} params.organization - The owning organization
+   * @param {string} params.creatorSlackUserId - Slack user ID of the proposer
+   * @param {Object} params.client - Slack client
+   */
+  async notifyOrgAdminsOfPendingTeam({
+    team,
+    organization,
+    creatorSlackUserId,
+    client,
+  }) {
+    try {
+      const admins = await userService.getOrganizationAdmins(organization.id);
+      const text = `🆕 <@${creatorSlackUserId}> proposed a new team "${team.name}" that needs your approval.`;
+      const blocks = createTeamApprovalRequestBlocks({
+        team,
+        creatorSlackUserId,
+      });
+
+      for (const admin of admins) {
+        if (admin.user.slackUserId === creatorSlackUserId) {
+          continue;
+        }
+
+        await client.chat.postMessage({
+          channel: admin.user.slackUserId,
+          text,
+          blocks,
+        });
+      }
+    } catch (error) {
+      logger.error("Error notifying org admins of pending team:", error);
+      // Don't throw - team creation succeeded; notification failure shouldn't break the flow
     }
   }
 }

--- a/src/services/notificationService.js
+++ b/src/services/notificationService.js
@@ -1,6 +1,7 @@
 const teamService = require("./teamService");
 const userService = require("./userService");
 const logger = require("../utils/logger");
+const { escapeSlackText } = require("../utils/messageHelper");
 const {
   createAdminSubmissionNotificationBlocks,
   createTeamApprovalRequestBlocks,
@@ -149,7 +150,9 @@ class NotificationService {
   }) {
     try {
       const admins = await userService.getOrganizationAdmins(organization.id);
-      const text = `🆕 <@${creatorSlackUserId}> proposed a new team "${team.name}" that needs your approval.`;
+      const text = `🆕 <@${creatorSlackUserId}> proposed a new team "${escapeSlackText(
+        team.name
+      )}" that needs your approval.`;
       const blocks = createTeamApprovalRequestBlocks({
         team,
         creatorSlackUserId,
@@ -160,11 +163,20 @@ class NotificationService {
           continue;
         }
 
-        await client.chat.postMessage({
-          channel: admin.user.slackUserId,
-          text,
-          blocks,
-        });
+        // Isolate per-recipient failures so one bad DM (e.g. a deactivated
+        // admin) doesn't stop the rest of the fan-out.
+        try {
+          await client.chat.postMessage({
+            channel: admin.user.slackUserId,
+            text,
+            blocks,
+          });
+        } catch (postError) {
+          logger.error(
+            `Failed pending-team DM to org admin ${admin.user.slackUserId}:`,
+            postError
+          );
+        }
       }
     } catch (error) {
       logger.error("Error notifying org admins of pending team:", error);

--- a/src/services/teamService.js
+++ b/src/services/teamService.js
@@ -20,24 +20,39 @@ function validateTimeString(timeString) {
 }
 
 class TeamService {
-  async createTeam(slackUserId, channelId, teamData, slackClient = null) {
+  async createTeam(
+    slackUserId,
+    channelId,
+    teamData,
+    slackWorkspaceId = null,
+    slackClient = null
+  ) {
     // Get user and their organization
     const userData = await userService.fetchSlackUserData(
       slackUserId,
       slackClient
     );
     const user = await userService.findOrCreateUser(slackUserId, userData);
-    const org = await userService.getUserOrganization(slackUserId);
+    let org = await userService.getUserOrganization(slackUserId);
 
+    // If the creator isn't an organization member yet, place them in the org
+    // that owns this Slack workspace and add them as a MEMBER (mirrors how
+    // joinTeam auto-onboards). This removes the "ask an admin to add you"
+    // barrier — anyone in the workspace can propose a team.
     if (!org) {
-      throw new Error("You must belong to an organization to create teams");
+      org = await userService.getOrganizationByWorkspaceId(slackWorkspaceId);
+      if (!org) {
+        throw new Error(
+          "This Slack workspace isn't set up with Daily Dose yet. Please ask an organization admin to set it up."
+        );
+      }
+      await userService.addUserToOrganization(user.id, org.id);
     }
 
-    // Check permissions
-    const canCreate = await userService.canCreateTeam(user.id, org.id);
-    if (!canCreate) {
-      throw new Error("You need admin permissions to create teams");
-    }
+    // Org owners/admins create teams that are active immediately. Everyone else
+    // creates a team that stays PENDING until an org admin approves it.
+    const isPrivileged = await userService.canCreateTeam(user.id, org.id);
+    const status = isPrivileged ? "ACTIVE" : "PENDING";
 
     // Check if channel already has a team
     const existingTeam = await prisma.team.findUnique({
@@ -49,8 +64,8 @@ class TeamService {
     }
 
     // Create team with transaction
-    return await prisma.$transaction(async (tx) => {
-      const team = await tx.team.create({
+    const team = await prisma.$transaction(async (tx) => {
+      const created = await tx.team.create({
         data: {
           organizationId: org.id,
           name: teamData.name,
@@ -58,20 +73,105 @@ class TeamService {
           standupTime: validateTimeString(teamData.standupTime),
           postingTime: validateTimeString(teamData.postingTime),
           timezone: validateTimezone(teamData.timezone || org.defaultTimezone),
+          status,
         },
       });
 
       // Add creator as team admin
       await tx.teamMember.create({
         data: {
-          teamId: team.id,
+          teamId: created.id,
           userId: user.id,
           role: "ADMIN",
         },
       });
 
-      return team;
+      return created;
     });
+
+    return { team, status, organization: org, creatorSlackUserId: slackUserId };
+  }
+
+  // Resolve and authorize an org admin acting on a PENDING team, returning the
+  // team (with its creator) for approve/reject handlers.
+  async getPendingTeamForDecision(
+    adminSlackUserId,
+    teamId,
+    slackClient = null
+  ) {
+    const userData = await userService.fetchSlackUserData(
+      adminSlackUserId,
+      slackClient
+    );
+    const adminUser = await userService.findOrCreateUser(
+      adminSlackUserId,
+      userData
+    );
+
+    const team = await prisma.team.findUnique({
+      where: { id: teamId },
+      include: {
+        organization: true,
+        members: {
+          where: { role: "ADMIN" },
+          include: { user: true },
+          orderBy: { createdAt: "asc" },
+        },
+      },
+    });
+
+    if (!team) {
+      throw new Error("Team not found");
+    }
+
+    const isOwner = await permissionHelper.isOrganizationOwner(
+      adminUser.id,
+      team.organizationId
+    );
+    const isOrgAdmin = await permissionHelper.isOrganizationAdmin(
+      adminUser.id,
+      team.organizationId
+    );
+    if (!isOwner && !isOrgAdmin) {
+      throw new Error("Only organization admins can approve or reject teams");
+    }
+
+    if (team.status !== "PENDING") {
+      throw new Error(
+        `This team has already been ${team.status.toLowerCase()}`
+      );
+    }
+
+    return { team, creatorSlackUserId: team.members[0]?.user?.slackUserId };
+  }
+
+  async approveTeam(adminSlackUserId, teamId, slackClient = null) {
+    const { creatorSlackUserId } = await this.getPendingTeamForDecision(
+      adminSlackUserId,
+      teamId,
+      slackClient
+    );
+
+    const updated = await prisma.team.update({
+      where: { id: teamId },
+      data: { status: "ACTIVE" },
+    });
+
+    return { team: updated, creatorSlackUserId };
+  }
+
+  async rejectTeam(adminSlackUserId, teamId, slackClient = null) {
+    const { team, creatorSlackUserId } = await this.getPendingTeamForDecision(
+      adminSlackUserId,
+      teamId,
+      slackClient
+    );
+
+    // Delete the rejected team so the channel is freed for a fresh proposal.
+    // Cascade deletes remove the creator's TeamMember record.
+    await prisma.team.delete({ where: { id: teamId } });
+
+    return { team, creatorSlackUserId };
   }
 
   async joinTeam(slackUserId, teamId, slackClient = null) {
@@ -235,6 +335,7 @@ class TeamService {
     return await prisma.team.findMany({
       where: {
         isActive: true,
+        status: "ACTIVE",
         organization: {
           isActive: true,
         },

--- a/src/services/teamService.js
+++ b/src/services/teamService.js
@@ -20,6 +20,18 @@ function validateTimeString(timeString) {
 }
 
 class TeamService {
+  /**
+   * Create a team for a Slack channel, auto-onboarding the creator into the
+   * workspace's organization if they aren't a member yet. Org owners/admins get
+   * an ACTIVE team immediately; everyone else gets a PENDING team that an org
+   * admin must approve before it is scheduled.
+   * @param {string} slackUserId - Slack user ID of the creator
+   * @param {string} channelId - Slack channel ID the team posts to
+   * @param {Object} teamData - { name, standupTime, postingTime, timezone? }
+   * @param {string|null} slackWorkspaceId - Slack workspace ID (command.team_id) used to resolve the org for non-members
+   * @param {Object|null} slackClient - Slack web client for fetching user info
+   * @returns {Promise<{team: Object, status: string, organization: Object, creatorSlackUserId: string}>}
+   */
   async createTeam(
     slackUserId,
     channelId,
@@ -92,8 +104,15 @@ class TeamService {
     return { team, status, organization: org, creatorSlackUserId: slackUserId };
   }
 
-  // Resolve and authorize an org admin acting on a PENDING team, returning the
-  // team (with its creator) for approve/reject handlers.
+  /**
+   * Resolve and authorize an org admin acting on a PENDING team, returning the
+   * team (with its creator) for approve/reject handlers. Throws if the team is
+   * missing, the actor isn't an org owner/admin, or the team isn't PENDING.
+   * @param {string} adminSlackUserId - Slack user ID of the acting admin
+   * @param {string} teamId - Team ID under decision
+   * @param {Object|null} slackClient - Slack web client for fetching user info
+   * @returns {Promise<{team: Object, creatorSlackUserId: string|undefined}>}
+   */
   async getPendingTeamForDecision(
     adminSlackUserId,
     teamId,
@@ -115,7 +134,7 @@ class TeamService {
         members: {
           where: { role: "ADMIN" },
           include: { user: true },
-          orderBy: { createdAt: "asc" },
+          orderBy: { joinedAt: "asc" },
         },
       },
     });
@@ -145,6 +164,13 @@ class TeamService {
     return { team, creatorSlackUserId: team.members[0]?.user?.slackUserId };
   }
 
+  /**
+   * Approve a PENDING team: transition it to ACTIVE so it can be scheduled.
+   * @param {string} adminSlackUserId - Slack user ID of the approving admin
+   * @param {string} teamId - Team ID to approve
+   * @param {Object|null} slackClient - Slack web client for fetching user info
+   * @returns {Promise<{team: Object, creatorSlackUserId: string|undefined}>}
+   */
   async approveTeam(adminSlackUserId, teamId, slackClient = null) {
     const { creatorSlackUserId } = await this.getPendingTeamForDecision(
       adminSlackUserId,
@@ -152,14 +178,29 @@ class TeamService {
       slackClient
     );
 
-    const updated = await prisma.team.update({
-      where: { id: teamId },
+    // Guard against a concurrent decision (two admins clicking at once): only
+    // flip a team that is still PENDING, so a stale click can't re-process it.
+    const { count } = await prisma.team.updateMany({
+      where: { id: teamId, status: "PENDING" },
       data: { status: "ACTIVE" },
     });
+    if (count === 0) {
+      throw new Error("This team has already been processed");
+    }
+
+    const updated = await prisma.team.findUnique({ where: { id: teamId } });
 
     return { team: updated, creatorSlackUserId };
   }
 
+  /**
+   * Reject a PENDING team: delete it so the channel is freed for a fresh
+   * proposal. Returns the team snapshot and creator for notifying the proposer.
+   * @param {string} adminSlackUserId - Slack user ID of the rejecting admin
+   * @param {string} teamId - Team ID to reject
+   * @param {Object|null} slackClient - Slack web client for fetching user info
+   * @returns {Promise<{team: Object, creatorSlackUserId: string|undefined}>}
+   */
   async rejectTeam(adminSlackUserId, teamId, slackClient = null) {
     const { team, creatorSlackUserId } = await this.getPendingTeamForDecision(
       adminSlackUserId,
@@ -168,8 +209,14 @@ class TeamService {
     );
 
     // Delete the rejected team so the channel is freed for a fresh proposal.
-    // Cascade deletes remove the creator's TeamMember record.
-    await prisma.team.delete({ where: { id: teamId } });
+    // Cascade deletes remove the creator's TeamMember record. Scope the delete
+    // to PENDING so a concurrent decision can't remove a just-approved team.
+    const { count } = await prisma.team.deleteMany({
+      where: { id: teamId, status: "PENDING" },
+    });
+    if (count === 0) {
+      throw new Error("This team has already been processed");
+    }
 
     return { team, creatorSlackUserId };
   }

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -87,8 +87,10 @@ class UserService {
   async getOrganizationByWorkspaceId(slackWorkspaceId) {
     if (!slackWorkspaceId) return null;
 
-    return await prisma.organization.findUnique({
-      where: { slackWorkspaceId },
+    // Only resolve active organizations so onboarding/team creation can't be
+    // routed into a deactivated org (the scheduler also filters on isActive).
+    return await prisma.organization.findFirst({
+      where: { slackWorkspaceId, isActive: true },
     });
   }
 

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -80,6 +80,31 @@ class UserService {
     return user.organizations[0].organization;
   }
 
+  // Resolve the organization for a Slack workspace. Used when a user who is not
+  // yet an organization member runs a command (e.g. creating a team) — we can
+  // still place them in the right org based on the workspace the command came
+  // from. Returns null if the workspace has no Daily Dose organization.
+  async getOrganizationByWorkspaceId(slackWorkspaceId) {
+    if (!slackWorkspaceId) return null;
+
+    return await prisma.organization.findUnique({
+      where: { slackWorkspaceId },
+    });
+  }
+
+  // List the active OWNER/ADMIN members of an organization, including their
+  // user records. Used to notify org admins of actions that need approval.
+  async getOrganizationAdmins(organizationId) {
+    return await prisma.organizationMember.findMany({
+      where: {
+        organizationId,
+        role: { in: ["OWNER", "ADMIN"] },
+        isActive: true,
+      },
+      include: { user: true },
+    });
+  }
+
   // Look up a user by Slack username (without the leading @) within a given
   // organization. Used to resolve targets for admin commands when the Slack
   // user can no longer be @-mentioned (e.g., already deactivated in Slack).

--- a/src/utils/blockHelper.js
+++ b/src/utils/blockHelper.js
@@ -343,6 +343,52 @@ function createStandupReminderBlocks(message, teamName, teamId) {
 }
 
 /**
+ * Build the DM sent to org admins asking them to approve/reject a new team
+ * proposed by a non-admin member.
+ * @param {object} params
+ * @param {object} params.team - Team record (id, name, standupTime, postingTime, timezone)
+ * @param {string} params.creatorSlackUserId - Slack user ID of the proposer
+ * @returns {Array<object>} Block Kit blocks with approve/reject buttons
+ */
+function createTeamApprovalRequestBlocks({ team, creatorSlackUserId }) {
+  return [
+    createSectionBlock(
+      `🆕 *New team pending approval*\n*Team:* ${team.name}\n*Channel:* <#${team.slackChannelId}>\n*Requested by:* <@${creatorSlackUserId}>`
+    ),
+    createContextBlock(
+      `Standup ${team.standupTime} • Posting ${team.postingTime} • ${team.timezone}`
+    ),
+    createActionsBlock([
+      createButton("✅ Approve", `approve_team_${team.id}`, team.id, "primary"),
+      createButton("❌ Reject", `reject_team_${team.id}`, team.id, "danger"),
+    ]),
+  ];
+}
+
+/**
+ * Replacement blocks shown after an org admin approves/rejects a team, so the
+ * original request message no longer offers stale buttons.
+ * @param {object} params
+ * @param {string} params.teamName - Team name
+ * @param {string} params.channelId - Slack channel ID of the team
+ * @param {string} params.decidedBySlackUserId - Slack user ID of the deciding admin
+ * @param {boolean} params.approved - Whether the team was approved
+ * @returns {Array<object>} Block Kit blocks describing the decision
+ */
+function createTeamApprovalResultBlocks({
+  teamName,
+  channelId,
+  decidedBySlackUserId,
+  approved,
+}) {
+  const status = approved ? "✅ *Approved*" : "❌ *Rejected*";
+  return [
+    createSectionBlock(`${status} — team *${teamName}* (<#${channelId}>)`),
+    createContextBlock(`Decision by <@${decidedBySlackUserId}>`),
+  ];
+}
+
+/**
  * Create standup summary header blocks
  * @param {string} teamName - Team name
  * @param {string} date - Date string
@@ -798,6 +844,8 @@ module.exports = {
   createStandupModal,
   createStandupUpdateModal,
   createStandupReminderBlocks,
+  createTeamApprovalRequestBlocks,
+  createTeamApprovalResultBlocks,
   createStandupSummaryHeader,
   createUserResponseBlocks,
   createLateResponseBlocks,

--- a/src/utils/blockHelper.js
+++ b/src/utils/blockHelper.js
@@ -2,7 +2,7 @@
  * Utility functions for generating Slack Block Kit components
  */
 
-const { convertTextToRichText } = require("./messageHelper");
+const { convertTextToRichText, escapeSlackText } = require("./messageHelper");
 
 /**
  * Create a basic section block with markdown text
@@ -351,12 +351,18 @@ function createStandupReminderBlocks(message, teamName, teamId) {
  * @returns {Array<object>} Block Kit blocks with approve/reject buttons
  */
 function createTeamApprovalRequestBlocks({ team, creatorSlackUserId }) {
+  // Team name is user-supplied — escape it so it can't inject Slack
+  // mentions/links/formatting into the admin DM.
   return [
     createSectionBlock(
-      `🆕 *New team pending approval*\n*Team:* ${team.name}\n*Channel:* <#${team.slackChannelId}>\n*Requested by:* <@${creatorSlackUserId}>`
+      `🆕 *New team pending approval*\n*Team:* ${escapeSlackText(
+        team.name
+      )}\n*Channel:* <#${team.slackChannelId}>\n*Requested by:* <@${creatorSlackUserId}>`
     ),
     createContextBlock(
-      `Standup ${team.standupTime} • Posting ${team.postingTime} • ${team.timezone}`
+      `Standup ${escapeSlackText(team.standupTime)} • Posting ${escapeSlackText(
+        team.postingTime
+      )} • ${escapeSlackText(team.timezone)}`
     ),
     createActionsBlock([
       createButton("✅ Approve", `approve_team_${team.id}`, team.id, "primary"),
@@ -383,7 +389,9 @@ function createTeamApprovalResultBlocks({
 }) {
   const status = approved ? "✅ *Approved*" : "❌ *Rejected*";
   return [
-    createSectionBlock(`${status} — team *${teamName}* (<#${channelId}>)`),
+    createSectionBlock(
+      `${status} — team *${escapeSlackText(teamName)}* (<#${channelId}>)`
+    ),
     createContextBlock(`Decision by <@${decidedBySlackUserId}>`),
   ];
 }

--- a/test/services/teamServiceApproval.test.js
+++ b/test/services/teamServiceApproval.test.js
@@ -1,0 +1,164 @@
+jest.mock("../../src/config/prisma", () => ({
+  team: {
+    findUnique: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
+  teamMember: { create: jest.fn() },
+  $transaction: jest.fn(),
+}));
+
+jest.mock("../../src/services/userService", () => ({
+  fetchSlackUserData: jest.fn().mockResolvedValue({}),
+  findOrCreateUser: jest.fn(),
+  getUserOrganization: jest.fn(),
+  getOrganizationByWorkspaceId: jest.fn(),
+  addUserToOrganization: jest.fn(),
+  canCreateTeam: jest.fn(),
+}));
+
+jest.mock("../../src/utils/permissionHelper", () => ({
+  isOrganizationOwner: jest.fn(),
+  isOrganizationAdmin: jest.fn(),
+}));
+
+const prisma = require("../../src/config/prisma");
+const userService = require("../../src/services/userService");
+const permissionHelper = require("../../src/utils/permissionHelper");
+const teamService = require("../../src/services/teamService");
+
+const org = { id: "o1", defaultTimezone: "America/New_York" };
+const teamData = { name: "Eng", standupTime: "09:30", postingTime: "10:00" };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  userService.findOrCreateUser.mockResolvedValue({ id: "u1" });
+  // $transaction runs the callback against the prisma mock itself
+  prisma.$transaction.mockImplementation(async (cb) => cb(prisma));
+  prisma.team.findUnique.mockResolvedValue(null);
+  prisma.team.create.mockImplementation(async ({ data }) => ({
+    id: "t1",
+    ...data,
+  }));
+  prisma.teamMember.create.mockResolvedValue({});
+});
+
+describe("teamService.createTeam approval gating", () => {
+  it("auto-onboards a non-member and creates a PENDING team", async () => {
+    userService.getUserOrganization.mockResolvedValue(null);
+    userService.getOrganizationByWorkspaceId.mockResolvedValue(org);
+    userService.canCreateTeam.mockResolvedValue(false);
+
+    const result = await teamService.createTeam(
+      "U_NEW",
+      "C123",
+      teamData,
+      "T_WORKSPACE"
+    );
+
+    expect(userService.getOrganizationByWorkspaceId).toHaveBeenCalledWith(
+      "T_WORKSPACE"
+    );
+    expect(userService.addUserToOrganization).toHaveBeenCalledWith("u1", "o1");
+    expect(result.status).toBe("PENDING");
+    expect(result.team.status).toBe("PENDING");
+    expect(result.creatorSlackUserId).toBe("U_NEW");
+  });
+
+  it("creates an ACTIVE team for an org admin without auto-onboarding", async () => {
+    userService.getUserOrganization.mockResolvedValue(org);
+    userService.canCreateTeam.mockResolvedValue(true);
+
+    const result = await teamService.createTeam("U_ADMIN", "C123", teamData);
+
+    expect(userService.addUserToOrganization).not.toHaveBeenCalled();
+    expect(result.status).toBe("ACTIVE");
+    expect(result.team.status).toBe("ACTIVE");
+  });
+
+  it("throws when the workspace has no organization", async () => {
+    userService.getUserOrganization.mockResolvedValue(null);
+    userService.getOrganizationByWorkspaceId.mockResolvedValue(null);
+
+    await expect(
+      teamService.createTeam("U_NEW", "C123", teamData, "T_UNKNOWN")
+    ).rejects.toThrow(/isn't set up with Daily Dose/);
+  });
+
+  it("rejects creation when the channel already has a team", async () => {
+    userService.getUserOrganization.mockResolvedValue(org);
+    userService.canCreateTeam.mockResolvedValue(true);
+    prisma.team.findUnique.mockResolvedValue({ id: "existing" });
+
+    await expect(
+      teamService.createTeam("U_ADMIN", "C123", teamData)
+    ).rejects.toThrow(/already has a team/);
+  });
+});
+
+describe("teamService.approveTeam / rejectTeam", () => {
+  const pendingTeam = {
+    id: "t1",
+    name: "Eng",
+    slackChannelId: "C123",
+    status: "PENDING",
+    organizationId: "o1",
+    organization: org,
+    members: [{ user: { slackUserId: "U_CREATOR" } }],
+  };
+
+  it("approves a pending team as an org admin", async () => {
+    prisma.team.findUnique.mockResolvedValue(pendingTeam);
+    permissionHelper.isOrganizationOwner.mockResolvedValue(false);
+    permissionHelper.isOrganizationAdmin.mockResolvedValue(true);
+    prisma.team.update.mockResolvedValue({
+      ...pendingTeam,
+      status: "ACTIVE",
+    });
+
+    const result = await teamService.approveTeam("U_ADMIN", "t1");
+
+    expect(prisma.team.update).toHaveBeenCalledWith({
+      where: { id: "t1" },
+      data: { status: "ACTIVE" },
+    });
+    expect(result.team.status).toBe("ACTIVE");
+    expect(result.creatorSlackUserId).toBe("U_CREATOR");
+  });
+
+  it("blocks approval from a non-admin", async () => {
+    prisma.team.findUnique.mockResolvedValue(pendingTeam);
+    permissionHelper.isOrganizationOwner.mockResolvedValue(false);
+    permissionHelper.isOrganizationAdmin.mockResolvedValue(false);
+
+    await expect(teamService.approveTeam("U_RANDOM", "t1")).rejects.toThrow(
+      /Only organization admins/
+    );
+    expect(prisma.team.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects (deletes) a pending team as an org admin", async () => {
+    prisma.team.findUnique.mockResolvedValue(pendingTeam);
+    permissionHelper.isOrganizationOwner.mockResolvedValue(true);
+    permissionHelper.isOrganizationAdmin.mockResolvedValue(false);
+
+    const result = await teamService.rejectTeam("U_OWNER", "t1");
+
+    expect(prisma.team.delete).toHaveBeenCalledWith({ where: { id: "t1" } });
+    expect(result.creatorSlackUserId).toBe("U_CREATOR");
+  });
+
+  it("refuses to act on a team that is not pending", async () => {
+    prisma.team.findUnique.mockResolvedValue({
+      ...pendingTeam,
+      status: "ACTIVE",
+    });
+    permissionHelper.isOrganizationOwner.mockResolvedValue(true);
+    permissionHelper.isOrganizationAdmin.mockResolvedValue(false);
+
+    await expect(teamService.approveTeam("U_OWNER", "t1")).rejects.toThrow(
+      /already been active/
+    );
+  });
+});

--- a/test/services/teamServiceApproval.test.js
+++ b/test/services/teamServiceApproval.test.js
@@ -3,7 +3,9 @@ jest.mock("../../src/config/prisma", () => ({
     findUnique: jest.fn(),
     create: jest.fn(),
     update: jest.fn(),
+    updateMany: jest.fn(),
     delete: jest.fn(),
+    deleteMany: jest.fn(),
   },
   teamMember: { create: jest.fn() },
   $transaction: jest.fn(),
@@ -109,22 +111,36 @@ describe("teamService.approveTeam / rejectTeam", () => {
   };
 
   it("approves a pending team as an org admin", async () => {
-    prisma.team.findUnique.mockResolvedValue(pendingTeam);
+    prisma.team.findUnique
+      .mockResolvedValueOnce(pendingTeam) // getPendingTeamForDecision lookup
+      .mockResolvedValueOnce({ ...pendingTeam, status: "ACTIVE" }); // re-read after update
     permissionHelper.isOrganizationOwner.mockResolvedValue(false);
     permissionHelper.isOrganizationAdmin.mockResolvedValue(true);
-    prisma.team.update.mockResolvedValue({
-      ...pendingTeam,
-      status: "ACTIVE",
-    });
+    prisma.team.updateMany.mockResolvedValue({ count: 1 });
 
     const result = await teamService.approveTeam("U_ADMIN", "t1");
 
-    expect(prisma.team.update).toHaveBeenCalledWith({
-      where: { id: "t1" },
+    // Status flip is guarded on the PENDING state to avoid a check-then-act race.
+    expect(prisma.team.updateMany).toHaveBeenCalledWith({
+      where: { id: "t1", status: "PENDING" },
       data: { status: "ACTIVE" },
     });
     expect(result.team.status).toBe("ACTIVE");
     expect(result.creatorSlackUserId).toBe("U_CREATOR");
+  });
+
+  it("queries pending-team members ordered by joinedAt (valid Prisma field)", async () => {
+    prisma.team.findUnique
+      .mockResolvedValueOnce(pendingTeam)
+      .mockResolvedValueOnce({ ...pendingTeam, status: "ACTIVE" });
+    permissionHelper.isOrganizationOwner.mockResolvedValue(true);
+    permissionHelper.isOrganizationAdmin.mockResolvedValue(false);
+    prisma.team.updateMany.mockResolvedValue({ count: 1 });
+
+    await teamService.approveTeam("U_OWNER", "t1");
+
+    const findArgs = prisma.team.findUnique.mock.calls[0][0];
+    expect(findArgs.include.members.orderBy).toEqual({ joinedAt: "asc" });
   });
 
   it("blocks approval from a non-admin", async () => {
@@ -135,18 +151,32 @@ describe("teamService.approveTeam / rejectTeam", () => {
     await expect(teamService.approveTeam("U_RANDOM", "t1")).rejects.toThrow(
       /Only organization admins/
     );
-    expect(prisma.team.update).not.toHaveBeenCalled();
+    expect(prisma.team.updateMany).not.toHaveBeenCalled();
   });
 
   it("rejects (deletes) a pending team as an org admin", async () => {
     prisma.team.findUnique.mockResolvedValue(pendingTeam);
     permissionHelper.isOrganizationOwner.mockResolvedValue(true);
     permissionHelper.isOrganizationAdmin.mockResolvedValue(false);
+    prisma.team.deleteMany.mockResolvedValue({ count: 1 });
 
     const result = await teamService.rejectTeam("U_OWNER", "t1");
 
-    expect(prisma.team.delete).toHaveBeenCalledWith({ where: { id: "t1" } });
+    expect(prisma.team.deleteMany).toHaveBeenCalledWith({
+      where: { id: "t1", status: "PENDING" },
+    });
     expect(result.creatorSlackUserId).toBe("U_CREATOR");
+  });
+
+  it("throws if a concurrent decision already processed the team", async () => {
+    prisma.team.findUnique.mockResolvedValue(pendingTeam);
+    permissionHelper.isOrganizationOwner.mockResolvedValue(true);
+    permissionHelper.isOrganizationAdmin.mockResolvedValue(false);
+    prisma.team.updateMany.mockResolvedValue({ count: 0 }); // lost the race
+
+    await expect(teamService.approveTeam("U_OWNER", "t1")).rejects.toThrow(
+      /already been processed/
+    );
   });
 
   it("refuses to act on a team that is not pending", async () => {

--- a/web/src/data/changelog.json
+++ b/web/src/data/changelog.json
@@ -1,9 +1,25 @@
 {
   "versions": [
     {
+      "version": "1.12.0",
+      "date": "2026-06-16",
+      "isLatest": true,
+      "changes": [
+        {
+          "type": "added",
+          "title": "Anyone can create a team — with admin approval",
+          "items": [
+            "You no longer need to be added to the organization first: just run /dd-team-create and you'll be onboarded automatically",
+            "If you're a regular member, your new team is sent to an organization admin for a quick Approve or Reject — you'll be notified the moment they decide, and standups start as soon as it's approved",
+            "Organization owners and admins still get instant team creation, no approval needed"
+          ]
+        }
+      ]
+    },
+    {
       "version": "1.11.0",
       "date": "2026-06-12",
-      "isLatest": true,
+      "isLatest": false,
       "changes": [
         {
           "type": "added",


### PR DESCRIPTION
## Problem

A user who wasn't already an organization member couldn't create a team. `teamService.createTeam` threw *"You must belong to an organization to create teams"* (no `OrganizationMember` record), and even members without an `OWNER`/`ADMIN` role hit *"You need admin permissions to create teams"*. The only path forward was asking an org admin to add them first.

## Solution

Self-service team creation with an org-admin approval gate:

- **Auto-onboarding** — anyone in the workspace can run `/dd-team-create`. A non-member is added to the workspace's organization as a `MEMBER`, resolving the org from the slash command's `team_id` (`Organization.slackWorkspaceId`). This mirrors how `joinTeam` already auto-onboards.
- **Approval gate** — teams created by org owners/admins go live immediately (`ACTIVE`). Teams created by regular members are saved as `PENDING` and are **not scheduled** until approved.
- **Approve/Reject** — org owners/admins receive a DM with Approve/Reject buttons. Approve flips the team to `ACTIVE` and schedules it; Reject deletes the team (freeing the channel). Either way the creator is DM'd the decision.

### Decisions captured from the requester
- Org creation stays manual (seed scripts) — no OAuth/install flow added. If a workspace has no organization yet, creation fails with a clear "ask an admin to set it up" message.
- Members can create teams, but an org admin must approve.
- Schema change ships as a real committed Prisma migration (repo convention).

## Changes
- **Schema/migration**: new `TeamStatus` enum (`PENDING`/`ACTIVE`/`REJECTED`) + `Team.status` column, default `ACTIVE` so existing teams stay active. Migration `20260616131600_team_status`.
- **`teamService`**: `createTeam` now takes `slackWorkspaceId` and returns `{ team, status, organization, creatorSlackUserId }`; new `getPendingTeamForDecision`/`approveTeam`/`rejectTeam`; `getActiveTeamsForScheduling` filters `status = ACTIVE`.
- **`userService`**: new `getOrganizationByWorkspaceId` and `getOrganizationAdmins`.
- **`notificationService`**: new `notifyOrgAdminsOfPendingTeam`.
- **`commands/team.js`**: create handler passes `command.team_id` and branches on pending vs. active; new `approveTeam`/`rejectTeam` action handlers. Registered `approve_team_*`/`reject_team_*` routes in `commands/index.js`.
- **`blockHelper`**: `createTeamApprovalRequestBlocks` / `createTeamApprovalResultBlocks`.
- **Docs**: README (commands, admin guide, troubleshooting), `CHANGELOG.md`, and user-facing `web/src/data/changelog.json`.

## Tests
`test/services/teamServiceApproval.test.js` covers auto-onboarding, pending vs. active creation, the no-org-for-workspace error, the duplicate-channel guard, and approve/reject permission + state transitions. Full suite: **102 passing**, lint clean.

## Notes
- No Slack manifest change needed — buttons use existing interactivity and DMs use the existing `chat:write` scope.
- Pending teams still appear in `/dd-team-list` and channel/name lookups (they're `isActive: true`); only automated scheduling is gated. Tightening manual command access to pending teams could be a follow-up if desired.

https://claude.ai/code/session_01MQar7W8tr287LWpcU89QRF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQar7W8tr287LWpcU89QRF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Any workspace member can now create teams.
  * Teams created by non-admins enter a pending state requiring org admin approval.
  * Org admins receive direct messages with approve/reject options for pending teams.
  * After approval, teams activate and creators become team admins.

* **Documentation**
  * Updated guides on team creation permissions and the approval process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->