### PR TITLE
feat(web): add proper favicon links and webmanifest

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/logo.png" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <meta name="theme-color" content="#ffffff" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Daily Dose - Automate Your Team Standups</title>
     <script>

--- a/web/public/site.webmanifest
+++ b/web/public/site.webmanifest
@@ -1,1 +1,1 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{"name":"Daily Dose","short_name":"Daily Dose","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Replaces the single `logo.png` icon reference in `index.html` with full favicon support
- Added `favicon.ico`, `favicon-16x16.png`, `favicon-32x32.png`, `apple-touch-icon.png`, and `site.webmanifest` link tags
- Updated `site.webmanifest` with the app name "Daily Dose" (was empty)
- Added `theme-color` meta tag

## Test plan

- [ ] Visit the web app and confirm the bot icon appears in the browser tab
- [ ] Check on iOS/Safari that the apple-touch-icon appears when adding to home screen
- [ ] Verify PWA install prompt works with the updated manifest

https://claude.ai/code/session_01WoLh7j7b8QC4vGQpEkxUjf
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLh7j7b8QC4vGQpEkxUjf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced favicon and icon support across browsers and devices for improved branding visibility.
  * Updated application metadata with official name for better recognition in system menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->