### PR TITLE
feat(mcp): standup auto-draft — preview tool + compose prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- MCP `preview_standup` tool (read-only): renders a standup draft for a team without saving it, reporting `willOverwrite`/`existing` and `isLate` so an agent can show a faithful preview before submitting. (`src/mcp/tools.js`)
+- MCP `compose_standup` prompt: guides an agent to gather work from its own connections (git/Jira/ClickUp/Trello), draft the standup, preview it, and submit only after explicit user confirmation. (`src/mcp/tools.js`)
+- `standupService.computeIsLate(team, standupDate)` extracted from `submitStandup` and reused by `preview_standup` (no behavior change). (`src/services/standupService.js`)
+- Reworded `submit_standup` tool description to instruct agents to preview and confirm before submitting. (`src/mcp/tools.js`)
+
 ## [1.14.0] - 2026-06-17
 
 ### Added

--- a/docs/superpowers/plans/2026-06-17-mcp-standup-autodraft.md
+++ b/docs/superpowers/plans/2026-06-17-mcp-standup-autodraft.md
@@ -1,0 +1,585 @@
+# MCP Standup Auto-Draft Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a read-only `preview_standup` MCP tool and a `compose_standup` MCP prompt so an AI agent can draft a standup from its own work connections, show a faithful preview, and submit only after explicit user confirmation.
+
+**Architecture:** Three additions in the existing MCP layer (`src/mcp/`) plus one small refactor in `standupService`. `preview_standup` renders a draft without writing; `compose_standup` is a server-side prompt that drives gather → draft → preview → confirm → submit; `submit_standup`'s description gains preview/confirm guidance. Daily Dose builds no third-party integrations — task-gathering is the agent's job.
+
+**Tech Stack:** Node.js, `@modelcontextprotocol/sdk` v1.29.0, zod, dayjs, Jest.
+
+**Spec:** `docs/superpowers/specs/2026-06-17-mcp-standup-autodraft-design.md`
+
+---
+
+## File Structure
+
+- **Modify** `src/services/standupService.js` — extract `computeIsLate(team, standupDate)` from `submitStandup`; both `submitStandup` and the new preview tool call it (DRY).
+- **Modify** `src/mcp/tools.js` — add a `formatStandupPreview` helper, a `composeStandupPromptText` helper, the `preview_standup` handler, its tool registration, the `compose_standup` prompt registration, and reword `submit_standup`'s description.
+- **Create** `test/services/standupService.computeIsLate.test.js` — unit tests for the extracted helper (late-boundary logic).
+- **Create** `test/mcp/tools.preview.test.js` — unit tests for the `preview_standup` handler.
+- **Modify** `test/mcp/server.test.js` — assert `preview_standup` tool and `compose_standup` prompt register.
+- **Modify** `web/src/data/mcpDocs.json`, `CHANGELOG.md` — docs + technical changelog. The user-facing `web/src/data/changelog.json` entry is **deferred to release time** (the `/release` flow folds user-visible changes under the cut version); its content is drafted in Task 4 but not inserted now.
+
+---
+
+## Task 1: Extract `computeIsLate` in standupService
+
+**Files:**
+
+- Modify: `src/services/standupService.js` (around lines 731-758)
+- Test: `test/services/standupService.computeIsLate.test.js` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/services/standupService.computeIsLate.test.js`:
+
+```js
+// computeIsLate is pure (dayjs + team config). Mock the heavy deps so requiring
+// the service stays offline.
+jest.mock("../../src/config/prisma", () => ({}));
+jest.mock("../../src/services/userService", () => ({}));
+jest.mock("../../src/services/notificationService", () => ({}));
+
+const dayjs = require("dayjs");
+const utc = require("dayjs/plugin/utc");
+const timezone = require("dayjs/plugin/timezone");
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+const standupService = require("../../src/services/standupService");
+
+const team = { timezone: "UTC", postingTime: "10:00" };
+
+describe("standupService.computeIsLate", () => {
+  it("is false for a past date regardless of time", () => {
+    const pastDate = dayjs().utc().subtract(3, "day").toDate();
+    expect(standupService.computeIsLate(team, pastDate)).toBe(false);
+  });
+
+  it("is true for today after the posting time", () => {
+    // Build a 'today' timestamp at 23:59 UTC, well past 10:00 posting time.
+    const lateToday = dayjs().utc().startOf("day").hour(23).minute(59).toDate();
+    expect(standupService.computeIsLate(team, lateToday)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest test/services/standupService.computeIsLate.test.js`
+Expected: FAIL — `standupService.computeIsLate is not a function`.
+
+- [ ] **Step 3: Add the `computeIsLate` method**
+
+In `src/services/standupService.js`, add this method immediately **before** `async submitStandup(`:
+
+```js
+  // Whether a submission for `standupDate` counts as late: only today-or-future
+  // dates can be late, and only once the team's posting time has passed.
+  computeIsLate(team, standupDate) {
+    const targetDate = dayjs(standupDate).tz(team.timezone);
+    const todayStart = dayjs().tz(team.timezone).startOf("day");
+
+    let isLate = false;
+    if (
+      targetDate.startOf("day").isSame(todayStart) ||
+      targetDate.startOf("day").isAfter(todayStart)
+    ) {
+      const [postingHour, postingMinute] = team.postingTime
+        .split(":")
+        .map(Number);
+      const postingTime = dayjs()
+        .tz(team.timezone)
+        .startOf("day")
+        .hour(postingHour)
+        .minute(postingMinute);
+      isLate = dayjs().tz(team.timezone).isAfter(postingTime);
+    }
+    return isLate;
+  }
+```
+
+- [ ] **Step 4: Refactor `submitStandup` to use it**
+
+In `src/services/standupService.js`, replace the inline `isLate` block (the `let isLate = false;` through the closing `}` of the `if`, currently lines ~744-758) with a single line:
+
+```js
+const isLate = this.computeIsLate(team, standupDate);
+```
+
+The surrounding lines stay: `const { yesterdayTasks = "", ... } = fields;`, `const targetDate = dayjs(standupDate).tz(team.timezone);` (still used later for the late-thread branch), and the `await this.saveResponse(...)` call. Delete the now-unused `const todayStart = ...` line only if nothing else below references it (it does not).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx jest test/services/standupService.computeIsLate.test.js`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Run the full suite to confirm no regression**
+
+Run: `npm test`
+Expected: PASS — existing standup/MCP tests still green (submitStandup behavior unchanged).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/services/standupService.js test/services/standupService.computeIsLate.test.js
+git commit -m "refactor(standup): extract computeIsLate helper"
+```
+
+---
+
+## Task 2: Add the `preview_standup` tool
+
+**Files:**
+
+- Modify: `src/mcp/tools.js`
+- Test: `test/mcp/tools.preview.test.js` (create)
+
+- [ ] **Step 1: Write the failing handler test**
+
+Create `test/mcp/tools.preview.test.js`:
+
+```js
+jest.mock("../../src/config/prisma", () => ({
+  teamMember: { findMany: jest.fn() },
+}));
+jest.mock("../../src/mcp/teamResolver", () => ({ resolveTeam: jest.fn() }));
+jest.mock("../../src/mcp/memberResolver", () => ({ resolveMember: jest.fn() }));
+jest.mock("../../src/utils/permissionHelper", () => ({
+  canManageTeam: jest.fn(),
+}));
+jest.mock("../../src/services/standupService", () => ({
+  submitStandup: jest.fn(),
+  getUserStandupHistory: jest.fn(),
+  getTeamResponses: jest.fn(),
+  getLateResponses: jest.fn(),
+  getActiveMembers: jest.fn(),
+  getUserResponse: jest.fn(),
+  computeIsLate: jest.fn(),
+}));
+jest.mock("../../src/services/teamService", () => ({ getTeamById: jest.fn() }));
+jest.mock("../../src/services/schedulerService", () => ({
+  sendStandupReminders: jest.fn(),
+  sendFollowupReminders: jest.fn(),
+}));
+
+const { resolveTeam } = require("../../src/mcp/teamResolver");
+const standupService = require("../../src/services/standupService");
+const teamService = require("../../src/services/teamService");
+const { buildToolHandlers } = require("../../src/mcp/tools");
+
+const user = { id: "user-1", slackUserId: "U1", name: "Alice" };
+const slackClient = { chat: { postMessage: jest.fn() } };
+const team = { id: "t1", name: "Eng", timezone: "UTC", postingTime: "10:00" };
+
+describe("preview_standup handler", () => {
+  let tools;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resolveTeam.mockResolvedValue({ team: { id: "t1", name: "Eng" } });
+    teamService.getTeamById.mockResolvedValue(team);
+    standupService.computeIsLate.mockReturnValue(false);
+    tools = buildToolHandlers(user, slackClient);
+  });
+
+  it("rejects when all fields are empty", async () => {
+    await expect(tools.preview_standup({ team: "Eng" })).rejects.toThrow(
+      /at least one field/i
+    );
+  });
+
+  it("renders a preview and reports willOverwrite=false when nothing exists", async () => {
+    standupService.getUserResponse.mockResolvedValue(null);
+    const result = await tools.preview_standup({
+      team: "Eng",
+      date: "2026-06-17",
+      yesterdayTasks: "Shipped auth",
+      todayTasks: "Code review",
+    });
+    expect(result.team).toBe("Eng");
+    expect(result.date).toBe("2026-06-17");
+    expect(result.willOverwrite).toBe(false);
+    expect(result.existing).toBeNull();
+    expect(result.fields).toEqual({
+      yesterdayTasks: "Shipped auth",
+      todayTasks: "Code review",
+      blockers: "",
+    });
+    expect(result.preview).toContain("Eng — 2026-06-17");
+    expect(result.preview).toContain("Shipped auth");
+    expect(standupService.submitStandup).not.toHaveBeenCalled();
+  });
+
+  it("reports willOverwrite=true with the existing submission", async () => {
+    standupService.getUserResponse.mockResolvedValue({
+      yesterdayTasks: "Old y",
+      todayTasks: "Old t",
+      blockers: "",
+    });
+    const result = await tools.preview_standup({
+      team: "Eng",
+      date: "2026-06-17",
+      todayTasks: "New plan",
+    });
+    expect(result.willOverwrite).toBe(true);
+    expect(result.existing).toEqual({
+      yesterdayTasks: "Old y",
+      todayTasks: "Old t",
+      blockers: "",
+    });
+  });
+
+  it("rejects an invalid date", async () => {
+    await expect(
+      tools.preview_standup({
+        team: "Eng",
+        date: "06-17-2026",
+        todayTasks: "x",
+      })
+    ).rejects.toThrow(/Invalid date/);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest test/mcp/tools.preview.test.js`
+Expected: FAIL — `tools.preview_standup is not a function`.
+
+- [ ] **Step 3: Add the `formatStandupPreview` module helper**
+
+In `src/mcp/tools.js`, add this function immediately after the `assertValidDate` function (module scope, before `buildToolHandlers`):
+
+```js
+function formatStandupPreview(teamName, date, fields) {
+  const { yesterdayTasks, todayTasks, blockers } = fields;
+  return [
+    `*${teamName} — ${date}*`,
+    `*Yesterday:* ${yesterdayTasks || "_(none)_"}`,
+    `*Today:* ${todayTasks || "_(none)_"}`,
+    `*Blockers:* ${blockers || "_(none)_"}`,
+  ].join("\n");
+}
+```
+
+- [ ] **Step 4: Add the `preview_standup` handler**
+
+In `src/mcp/tools.js`, inside the object returned by `buildToolHandlers`, add this handler immediately after the `update_standup` handler (after its closing `},`):
+
+```js
+    async preview_standup({
+      team,
+      date,
+      yesterdayTasks = "",
+      todayTasks = "",
+      blockers = "",
+    }) {
+      if (date) assertValidDate(date);
+      if (!yesterdayTasks && !todayTasks && !blockers) {
+        throw new Error(
+          "Provide at least one field (yesterdayTasks, todayTasks, or blockers)."
+        );
+      }
+      const resolved = await resolveOrThrow(team);
+      const full = await teamService.getTeamById(resolved.id);
+      const targetDate = date
+        ? dayjs(date, "YYYY-MM-DD").toDate()
+        : dayjs().tz(full.timezone).toDate();
+      const dateStr = dayjs(targetDate).tz(full.timezone).format("YYYY-MM-DD");
+
+      const existingRow = await standupService.getUserResponse(
+        full.id,
+        user.id,
+        targetDate
+      );
+      const existing = existingRow
+        ? {
+            yesterdayTasks: existingRow.yesterdayTasks || "",
+            todayTasks: existingRow.todayTasks || "",
+            blockers: existingRow.blockers || "",
+          }
+        : null;
+
+      const fields = { yesterdayTasks, todayTasks, blockers };
+      return {
+        team: resolved.name,
+        date: dateStr,
+        isLate: standupService.computeIsLate(full, targetDate),
+        willOverwrite: existing !== null,
+        existing,
+        fields,
+        preview: formatStandupPreview(resolved.name, dateStr, fields),
+      };
+    },
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx jest test/mcp/tools.preview.test.js`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Register the `preview_standup` tool**
+
+In `src/mcp/tools.js`, inside `registerTools`, add this registration immediately after the `update_standup` registration block (after its closing `);`):
+
+```js
+server.registerTool(
+  "preview_standup",
+  {
+    title: "Preview standup",
+    description:
+      "Render a standup draft for a team WITHOUT saving it, so you can show the user exactly what will be submitted. Returns the formatted preview, whether it will overwrite an existing submission (willOverwrite/existing), and whether it will count as late (isLate). Always call this and get the user's explicit confirmation before calling submit_standup or update_standup.",
+    inputSchema: z.object({
+      team: TEAM_FIELD,
+      date: z.string().optional().describe("YYYY-MM-DD; defaults to today"),
+      yesterdayTasks: z.string().optional(),
+      todayTasks: z.string().optional(),
+      blockers: z.string().optional(),
+    }),
+  },
+  async (args) => {
+    try {
+      return json(await handlers.preview_standup(args));
+    } catch (e) {
+      return fail(e);
+    }
+  }
+);
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/mcp/tools.js test/mcp/tools.preview.test.js
+git commit -m "feat(mcp): add preview_standup tool"
+```
+
+---
+
+## Task 3: Add the `compose_standup` prompt and reword `submit_standup`
+
+**Files:**
+
+- Modify: `src/mcp/tools.js`
+- Test: `test/mcp/server.test.js`
+
+- [ ] **Step 1: Write the failing registration test**
+
+In `test/mcp/server.test.js`, inside the `describe("registerTools SDK wiring", ...)` block, add a new test after the existing one:
+
+```js
+it("registers preview_standup and the compose_standup prompt", () => {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  const toolSpy = jest.spyOn(server, "registerTool");
+  const promptSpy = jest.spyOn(server, "registerPrompt");
+  const user = { id: "u1", slackUserId: "U1", name: "Alice" };
+  const slackClient = { chat: { postMessage: jest.fn() } };
+
+  expect(() => registerTools(server, user, slackClient)).not.toThrow();
+
+  expect(toolSpy.mock.calls.map((c) => c[0])).toEqual(
+    expect.arrayContaining(["preview_standup"])
+  );
+  expect(promptSpy.mock.calls.map((c) => c[0])).toEqual(
+    expect.arrayContaining(["compose_standup"])
+  );
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest test/mcp/server.test.js -t "compose_standup"`
+Expected: FAIL — `preview_standup`/`compose_standup` not found in the spied calls.
+
+(Note: `preview_standup` already exists from Task 2, so the tool assertion passes; the prompt assertion is what fails here.)
+
+- [ ] **Step 3: Add the `composeStandupPromptText` module helper**
+
+In `src/mcp/tools.js`, add this function at module scope (after `formatStandupPreview`):
+
+```js
+function composeStandupPromptText({ team, date } = {}) {
+  return [
+    "Help me submit my Daily Dose standup. Follow these steps:",
+    "",
+    `1. Determine the team.${
+      team
+        ? ` Use the team "${team}".`
+        : " Call list_my_teams; if I belong to more than one team and I haven't named one, ask me which team."
+    }`,
+    `2. Gather my work${
+      date ? ` for ${date}` : ""
+    } using whatever work connections you have (git commits/PRs, ClickUp, Jira, Trello, etc.): what I completed since my last working day, what I plan to do today, and any blockers. Do NOT invent work — if you find nothing, tell me.`,
+    "3. Map findings to three fields: yesterdayTasks (completed), todayTasks (planned), and blockers.",
+    `4. Call preview_standup with the team${
+      date ? `, date ${date},` : ""
+    } and the drafted fields.`,
+    "5. Show me the returned `preview` text verbatim. Warn me if willOverwrite is true (it replaces my existing submission) or isLate is true.",
+    "6. Ask me to confirm. Do NOT submit until I explicitly say yes.",
+    `7. When I confirm, call ${
+      date ? "update_standup (with the date)" : "submit_standup"
+    } using the same fields. If I ask for changes, revise and preview again.`,
+  ].join("\n");
+}
+```
+
+- [ ] **Step 4: Register the `compose_standup` prompt**
+
+In `src/mcp/tools.js`, inside `registerTools`, add this at the **end** of the function, immediately before its closing `}` (after the last `server.registerTool(...)` block):
+
+```js
+server.registerPrompt(
+  "compose_standup",
+  {
+    title: "Compose my standup",
+    description:
+      "Draft your standup from your connected work tools (git, Jira, ClickUp, Trello), preview it, and submit it after your confirmation.",
+    argsSchema: {
+      team: z
+        .string()
+        .optional()
+        .describe(
+          "Team name; you'll be asked if omitted and on multiple teams"
+        ),
+      date: z.string().optional().describe("YYYY-MM-DD; defaults to today"),
+    },
+  },
+  (args = {}) => ({
+    messages: [
+      {
+        role: "user",
+        content: { type: "text", text: composeStandupPromptText(args) },
+      },
+    ],
+  })
+);
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx jest test/mcp/server.test.js -t "compose_standup"`
+Expected: PASS.
+
+- [ ] **Step 6: Reword the `submit_standup` description**
+
+In `src/mcp/tools.js`, in the `submit_standup` registration, replace its `description` value with:
+
+```js
+      description:
+        "Submit today's standup for a team. At least one field is required. Before calling, draft the fields, call preview_standup, show the user the preview, and get explicit confirmation. Don't fabricate work the user didn't do.",
+```
+
+- [ ] **Step 7: Run the full MCP suite**
+
+Run: `npx jest test/mcp`
+Expected: PASS — all MCP tests green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/mcp/tools.js test/mcp/server.test.js
+git commit -m "feat(mcp): add compose_standup prompt and preview guidance"
+```
+
+---
+
+## Task 4: Docs and changelogs
+
+**Files:**
+
+- Modify: `web/src/data/mcpDocs.json`
+- Modify: `CHANGELOG.md`
+- (Deferred to release) `web/src/data/changelog.json` — content drafted below, not inserted now
+
+- [ ] **Step 1: Add an MCP docs subsection**
+
+In `web/src/data/mcpDocs.json`, insert this subsection object into the `subsections` array immediately **after** the `mcp-tools-everyone` subsection (and before `mcp-tools-admin`):
+
+```json
+        {
+          "id": "mcp-autodraft",
+          "title": "Let your agent draft your standup",
+          "content": [
+            {
+              "type": "note",
+              "title": "✍️ Draft from your other tools",
+              "value": "If your AI agent is also connected to your work tools (GitHub, Jira, ClickUp, Trello), it can gather what you did and draft your standup for you — then show you a preview and submit only after you confirm. Daily Dose never connects to those tools itself; it relies on the connections your agent already has."
+            },
+            {
+              "type": "text",
+              "value": "**Just ask** — for example: *“Draft my Engineering standup from my GitHub activity and show me a preview.”* In clients that support prompts (like Claude Desktop), you can also run the **compose_standup** prompt as a shortcut."
+            },
+            {
+              "type": "command",
+              "command": "preview_standup",
+              "description": "Render a standup draft for a team without saving it. Shows exactly what will be submitted, whether it will overwrite an existing entry, and whether it counts as late — so you can review before confirming.",
+              "examples": [
+                "# Your agent calls this, then shows you the preview and asks:\nReady to submit this standup to Engineering?"
+              ]
+            },
+            {
+              "type": "warning",
+              "title": "You always confirm",
+              "value": "Your agent is instructed to preview and get your explicit yes before submitting, and never to invent work you didn't do. Nothing is written to Daily Dose until you approve it."
+            }
+          ]
+        },
+```
+
+- [ ] **Step 2: Validate the JSON parses**
+
+Run: `node -e "JSON.parse(require('fs').readFileSync('web/src/data/mcpDocs.json','utf8')); console.log('ok')"`
+Expected: prints `ok`.
+
+- [ ] **Step 3: Add the CHANGELOG.md entry**
+
+In `CHANGELOG.md`, under `## [Unreleased]`, add an `### Added` section (create it if absent) with:
+
+```markdown
+- MCP `preview_standup` tool (read-only): renders a standup draft for a team without saving it, reporting `willOverwrite`/`existing` and `isLate` so an agent can show a faithful preview before submitting. (`src/mcp/tools.js`)
+- MCP `compose_standup` prompt: guides an agent to gather work from its own connections (git/Jira/ClickUp/Trello), draft the standup, preview it, and submit only after explicit user confirmation. (`src/mcp/tools.js`)
+- `standupService.computeIsLate(team, standupDate)` extracted from `submitStandup` and reused by `preview_standup` (no behavior change). (`src/services/standupService.js`)
+- Reworded `submit_standup` tool description to instruct agents to preview and confirm before submitting. (`src/mcp/tools.js`)
+```
+
+- [ ] **Step 4: Draft the user-facing changelog content (do NOT edit the file yet)**
+
+Do **not** insert a synthetic version into `web/src/data/changelog.json` — the `/release` flow adds user-facing entries under the cut version (with correct `isLatest` handling). Record this `changes` block in the PR description / hand it to the maintainer to fold in at release:
+
+```json
+{
+  "type": "added",
+  "title": "Let your AI agent draft your standup",
+  "items": [
+    "If your AI agent is connected to your work tools, it can gather what you did, draft your standup, and show you a preview before anything is submitted",
+    "You always confirm first — your agent never posts a standup without your explicit yes, and won't invent work you didn't do"
+  ]
+}
+```
+
+- [ ] **Step 5: Build the web app**
+
+Run: `cd web && npm run build`
+Expected: build succeeds (validates the `mcpDocs.json` change renders).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/data/mcpDocs.json CHANGELOG.md
+git commit -m "docs(mcp): document standup auto-draft (preview + compose prompt)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full test suite**
+
+Run: `npm test`
+Expected: all tests pass.
+
+- [ ] **Sanity-check tool/prompt registration against the real SDK**
+
+Run: `npx jest test/mcp/server.test.js`
+Expected: PASS — confirms `preview_standup` and `compose_standup` register without schema errors.

--- a/docs/superpowers/specs/2026-06-17-mcp-standup-autodraft-design.md
+++ b/docs/superpowers/specs/2026-06-17-mcp-standup-autodraft-design.md
@@ -1,0 +1,168 @@
+# MCP Standup Auto-Draft — Design
+
+**Date:** 2026-06-17
+**Status:** Approved (pending implementation plan)
+
+## Goal
+
+Let a team member ask their AI agent to do their standup, and have the agent:
+
+1. Gather "what I worked on" from **its own** connections (GitHub, Jira, ClickUp,
+   Trello — via other MCP servers or built-in tools).
+2. Draft the three standup fields (yesterday / today / blockers).
+3. Show a **faithful preview** of what will be submitted.
+4. Submit **only after explicit user confirmation**.
+
+This automates the tedious part of standup (recalling and writing up work) while
+keeping the human in the loop for accuracy.
+
+## Scope
+
+**In scope** (all under `src/mcp/`):
+
+- A read-only `preview_standup` tool.
+- An MCP prompt `compose_standup` that drives the gather → draft → preview →
+  confirm → submit choreography.
+- A reworded `submit_standup` description.
+- Docs + changelog updates.
+
+**Explicitly out of scope:**
+
+- Daily Dose builds **no** third-party integrations and stores **no** external
+  OAuth tokens. Task-gathering is the **agent's** job, using the agent's own
+  connections. Daily Dose only provides preview/submit tooling and guidance.
+- No server-enforced draft/confirm handshake (no draft tokens, no stateful draft
+  storage). The flow is stateless; confirmation is the agent's responsibility,
+  reinforced by the prompt, the `preview_standup` tool, and tool descriptions.
+
+## Architecture
+
+Three additions, all in the existing MCP layer. No new services, no schema
+changes.
+
+```
+user → "do my Engineering standup"
+  agent ─(its own MCP/tools)→ GitHub / Jira / ClickUp / Trello   # gather work
+  agent → preview_standup(team, drafted fields)                  # DD renders, NO write
+  agent → shows `preview`, surfaces willOverwrite/isLate, asks   # confirmation
+  user → "yes"
+  agent → submit_standup(team, fields)                           # DD writes (existing path)
+```
+
+The agent may loop preview ↔ edit before submitting. `submit_standup` is
+unchanged behaviorally — it remains the only write path.
+
+## Component: `preview_standup` tool
+
+Read-only. Resolves and validates exactly like `submit_standup`, but never
+writes. Identity-scoped via the existing `resolveTeam` (you can only preview for
+teams you belong to).
+
+**Input**
+
+| field            | type                | notes                                |
+| ---------------- | ------------------- | ------------------------------------ |
+| `team`           | string (required)   | team name or id                      |
+| `date`           | string `YYYY-MM-DD` | optional; default = today in team tz |
+| `yesterdayTasks` | string              | optional                             |
+| `todayTasks`     | string              | optional                             |
+| `blockers`       | string              | optional                             |
+
+At least one of the three task fields is required (same rule as
+`submit_standup`).
+
+**Output**
+
+```jsonc
+{
+  "team": "Engineering", // resolved name
+  "date": "2026-06-17",
+  "isLate": true, // past the team's standup window
+  "willOverwrite": true, // a submission already exists for this date
+  "existing": {
+    // null when nothing exists yet
+    "yesterdayTasks": "…",
+    "todayTasks": "…",
+    "blockers": "…",
+  },
+  "fields": {
+    // the draft, normalized
+    "yesterdayTasks": "…",
+    "todayTasks": "…",
+    "blockers": "…",
+  },
+  "preview": "*Engineering — 2026-06-17*\n*Yesterday:* …\n*Today:* …\n*Blockers:* …",
+}
+```
+
+`preview` is a ready-to-display string so the agent shows something faithful
+rather than improvising. `isLate` and `willOverwrite` are computed from the same
+helpers `submit_standup` already relies on — no new query logic is invented.
+
+## Component: `compose_standup` MCP prompt
+
+Surfaces as a slash-command in clients that support prompts (Claude Desktop,
+Cursor); degrades to tool-description guidance elsewhere.
+
+**Arguments:** `team` (optional), `date` (optional).
+
+**Instructs the agent to:**
+
+1. Resolve the team — call `list_my_teams`; if multiple teams and `team` not
+   given, ask the user which one.
+2. Gather **completed** work since the user's last working day and **planned**
+   work for today from whatever work connections the agent has (git commits/PRs,
+   issue trackers). Source-agnostic.
+3. Map findings to `yesterdayTasks` / `todayTasks` / `blockers`.
+4. Call `preview_standup` with the draft.
+5. Display the returned `preview`, surface `willOverwrite` and `isLate`, and ask
+   for **explicit confirmation**.
+6. On confirmation, call `submit_standup`. On requested edits, re-draft and
+   re-preview.
+
+**Hard rules baked into the prompt:** never submit without confirmation; if no
+work is found, say so rather than fabricating tasks.
+
+## Component: `submit_standup` description rewording
+
+Append guidance (no code/behavior change):
+
+> Before calling, draft the fields, call `preview_standup`, show the user the
+> preview, and get explicit confirmation. Don't fabricate work the user didn't
+> do.
+
+This covers clients that don't support MCP prompts.
+
+## Edge cases
+
+| Case                        | Handling                                                      |
+| --------------------------- | ------------------------------------------------------------- |
+| Multi-team, no team given   | Prompt has agent call `list_my_teams` and ask.                |
+| Submission already exists   | `willOverwrite: true` + `existing` so the user sees the swap. |
+| Past standup window         | `isLate: true` shown in preview; submit still allowed.        |
+| No work found by the agent  | Agent reports it; does not fabricate (prompt rule).           |
+| Not a member / invalid date | Same errors `submit_standup`/`resolveTeam` already throw.     |
+
+## Testing
+
+Jest, following `test/mcp/`:
+
+- `preview_standup`:
+  - renders `fields` and `preview` from inputs;
+  - `willOverwrite: true` + `existing` populated when a response exists, `false` +
+    `existing: null` when none;
+  - `isLate` boundary (before vs after the team window);
+  - date validation rejects malformed dates;
+  - "at least one field" rule enforced;
+  - **asserts no DB write** — team response count is unchanged after preview.
+- Registration: `preview_standup` tool **and** `compose_standup` prompt register
+  on the SDK server (extends the `server.test.js` pattern).
+- No tests for git/Jira/etc. — out of scope by design.
+
+## Docs & changelog
+
+- `web/src/data/mcpDocs.json`: new subsection ("Let your agent draft your
+  standup") explaining the prompt and the preview/confirm flow.
+- `CHANGELOG.md`: technical entry under `[Unreleased]`.
+- `web/src/data/changelog.json`: user-facing entry — this change **is**
+  user-visible.

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -25,6 +25,16 @@ function assertValidDate(date) {
   }
 }
 
+function formatStandupPreview(teamName, date, fields) {
+  const { yesterdayTasks, todayTasks, blockers } = fields;
+  return [
+    `*${teamName} — ${date}*`,
+    `*Yesterday:* ${yesterdayTasks || "_(none)_"}`,
+    `*Today:* ${todayTasks || "_(none)_"}`,
+    `*Blockers:* ${blockers || "_(none)_"}`,
+  ].join("\n");
+}
+
 /**
  * Plain async tool handlers bound to a specific user + Slack client.
  * Each throws Error on failure (the MCP layer converts to a tool error).
@@ -116,6 +126,51 @@ function buildToolHandlers(user, slackClient) {
         slackClient,
       });
       return { team: resolved.name, date, isLate };
+    },
+
+    async preview_standup({
+      team,
+      date,
+      yesterdayTasks = "",
+      todayTasks = "",
+      blockers = "",
+    }) {
+      if (date) assertValidDate(date);
+      if (!yesterdayTasks && !todayTasks && !blockers) {
+        throw new Error(
+          "Provide at least one field (yesterdayTasks, todayTasks, or blockers)."
+        );
+      }
+      const resolved = await resolveOrThrow(team);
+      const full = await teamService.getTeamById(resolved.id);
+      const targetDate = date
+        ? dayjs.tz(date, "YYYY-MM-DD", full.timezone).toDate()
+        : dayjs().tz(full.timezone).toDate();
+      const dateStr = dayjs(targetDate).tz(full.timezone).format("YYYY-MM-DD");
+
+      const existingRow = await standupService.getUserResponse(
+        full.id,
+        user.id,
+        targetDate
+      );
+      const existing = existingRow
+        ? {
+            yesterdayTasks: existingRow.yesterdayTasks || "",
+            todayTasks: existingRow.todayTasks || "",
+            blockers: existingRow.blockers || "",
+          }
+        : null;
+
+      const fields = { yesterdayTasks, todayTasks, blockers };
+      return {
+        team: resolved.name,
+        date: dateStr,
+        isLate: standupService.computeIsLate(full, targetDate),
+        willOverwrite: existing !== null,
+        existing,
+        fields,
+        preview: formatStandupPreview(resolved.name, dateStr, fields),
+      };
     },
 
     async get_my_standup_history({ startDate, endDate } = {}) {
@@ -445,6 +500,29 @@ function registerTools(server, user, slackClient) {
     async (args) => {
       try {
         return json(await handlers.update_standup(args));
+      } catch (e) {
+        return fail(e);
+      }
+    }
+  );
+
+  server.registerTool(
+    "preview_standup",
+    {
+      title: "Preview standup",
+      description:
+        "Render a standup draft for a team WITHOUT saving it, so you can show the user exactly what will be submitted. Returns the formatted preview, whether it will overwrite an existing submission (willOverwrite/existing), and whether it will count as late (isLate). Always call this and get the user's explicit confirmation before calling submit_standup or update_standup.",
+      inputSchema: z.object({
+        team: TEAM_FIELD,
+        date: z.string().optional().describe("YYYY-MM-DD; defaults to today"),
+        yesterdayTasks: z.string().optional(),
+        todayTasks: z.string().optional(),
+        blockers: z.string().optional(),
+      }),
+    },
+    async (args) => {
+      try {
+        return json(await handlers.preview_standup(args));
       } catch (e) {
         return fail(e);
       }

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -35,6 +35,30 @@ function formatStandupPreview(teamName, date, fields) {
   ].join("\n");
 }
 
+function composeStandupPromptText({ team, date } = {}) {
+  return [
+    "Help me submit my Daily Dose standup. Follow these steps:",
+    "",
+    `1. Determine the team.${
+      team
+        ? ` Use the team "${team}".`
+        : " Call list_my_teams; if I belong to more than one team and I haven't named one, ask me which team."
+    }`,
+    `2. Gather my work${
+      date ? ` for ${date}` : ""
+    } using whatever work connections you have (git commits/PRs, ClickUp, Jira, Trello, etc.): what I completed since my last working day, what I plan to do today, and any blockers. Do NOT invent work — if you find nothing, tell me.`,
+    "3. Map findings to three fields: yesterdayTasks (completed), todayTasks (planned), and blockers.",
+    `4. Call preview_standup with the team${
+      date ? `, date ${date},` : ""
+    } and the drafted fields.`,
+    "5. Show me the returned `preview` text verbatim. Warn me if willOverwrite is true (it replaces my existing submission) or isLate is true.",
+    "6. Ask me to confirm. Do NOT submit until I explicitly say yes.",
+    `7. When I confirm, call ${
+      date ? "update_standup (with the date)" : "submit_standup"
+    } using the same fields. If I ask for changes, revise and preview again.`,
+  ].join("\n");
+}
+
 /**
  * Plain async tool handlers bound to a specific user + Slack client.
  * Each throws Error on failure (the MCP layer converts to a tool error).
@@ -466,7 +490,7 @@ function registerTools(server, user, slackClient) {
     {
       title: "Submit standup",
       description:
-        "Submit today's standup for a team. At least one field is required.",
+        "Submit today's standup for a team. At least one field is required. Before calling, draft the fields, call preview_standup, show the user the preview, and get explicit confirmation. Don't fabricate work the user didn't do.",
       inputSchema: z.object({
         team: TEAM_FIELD,
         yesterdayTasks: z.string().optional(),
@@ -666,6 +690,32 @@ function registerTools(server, user, slackClient) {
         return fail(e);
       }
     }
+  );
+
+  server.registerPrompt(
+    "compose_standup",
+    {
+      title: "Compose my standup",
+      description:
+        "Draft your standup from your connected work tools (git, Jira, ClickUp, Trello), preview it, and submit it after your confirmation.",
+      argsSchema: {
+        team: z
+          .string()
+          .optional()
+          .describe(
+            "Team name; you'll be asked if omitted and on multiple teams"
+          ),
+        date: z.string().optional().describe("YYYY-MM-DD; defaults to today"),
+      },
+    },
+    (args = {}) => ({
+      messages: [
+        {
+          role: "user",
+          content: { type: "text", text: composeStandupPromptText(args) },
+        },
+      ],
+    })
   );
 }
 

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -29,7 +29,7 @@ function formatStandupPreview(teamName, date, fields) {
   const { yesterdayTasks, todayTasks, blockers } = fields;
   return [
     `*${teamName} — ${date}*`,
-    `*Yesterday:* ${yesterdayTasks || "_(none)_"}`,
+    `*Last working day:* ${yesterdayTasks || "_(none)_"}`,
     `*Today:* ${todayTasks || "_(none)_"}`,
     `*Blockers:* ${blockers || "_(none)_"}`,
   ].join("\n");
@@ -144,9 +144,9 @@ function buildToolHandlers(user, slackClient) {
       const resolved = await resolveOrThrow(team);
       const full = await teamService.getTeamById(resolved.id);
       const targetDate = date
-        ? dayjs.tz(date, "YYYY-MM-DD", full.timezone).toDate()
+        ? dayjs(date, "YYYY-MM-DD").toDate()
         : dayjs().tz(full.timezone).toDate();
-      const dateStr = dayjs(targetDate).tz(full.timezone).format("YYYY-MM-DD");
+      const dateStr = date || dayjs().tz(full.timezone).format("YYYY-MM-DD");
 
       const existingRow = await standupService.getUserResponse(
         full.id,

--- a/src/services/standupService.js
+++ b/src/services/standupService.js
@@ -728,16 +728,9 @@ class StandupService {
     }
   }
 
-  async submitStandup({
-    team,
-    slackUserId,
-    name,
-    fields,
-    standupDate,
-    isUpdate = false,
-    slackClient,
-  }) {
-    const { yesterdayTasks = "", todayTasks = "", blockers = "" } = fields;
+  // Whether a submission for `standupDate` counts as late: only today-or-future
+  // dates can be late, and only once the team's posting time has passed.
+  computeIsLate(team, standupDate) {
     const targetDate = dayjs(standupDate).tz(team.timezone);
     const todayStart = dayjs().tz(team.timezone).startOf("day");
 
@@ -756,6 +749,21 @@ class StandupService {
         .minute(postingMinute);
       isLate = dayjs().tz(team.timezone).isAfter(postingTime);
     }
+    return isLate;
+  }
+
+  async submitStandup({
+    team,
+    slackUserId,
+    name,
+    fields,
+    standupDate,
+    isUpdate = false,
+    slackClient,
+  }) {
+    const { yesterdayTasks = "", todayTasks = "", blockers = "" } = fields;
+    const targetDate = dayjs(standupDate).tz(team.timezone);
+    const isLate = this.computeIsLate(team, standupDate);
 
     await this.saveResponse(
       team.id,

--- a/test/mcp/server.test.js
+++ b/test/mcp/server.test.js
@@ -146,4 +146,21 @@ describe("registerTools SDK wiring", () => {
       ])
     );
   });
+
+  it("registers preview_standup and the compose_standup prompt", () => {
+    const server = new McpServer({ name: "test", version: "1.0.0" });
+    const toolSpy = jest.spyOn(server, "registerTool");
+    const promptSpy = jest.spyOn(server, "registerPrompt");
+    const user = { id: "u1", slackUserId: "U1", name: "Alice" };
+    const slackClient = { chat: { postMessage: jest.fn() } };
+
+    expect(() => registerTools(server, user, slackClient)).not.toThrow();
+
+    expect(toolSpy.mock.calls.map((c) => c[0])).toEqual(
+      expect.arrayContaining(["preview_standup"])
+    );
+    expect(promptSpy.mock.calls.map((c) => c[0])).toEqual(
+      expect.arrayContaining(["compose_standup"])
+    );
+  });
 });

--- a/test/mcp/tools.preview.test.js
+++ b/test/mcp/tools.preview.test.js
@@ -21,6 +21,8 @@ jest.mock("../../src/services/schedulerService", () => ({
   sendFollowupReminders: jest.fn(),
 }));
 
+const dayjs = require("dayjs");
+dayjs.extend(require("dayjs/plugin/customParseFormat"));
 const { resolveTeam } = require("../../src/mcp/teamResolver");
 const standupService = require("../../src/services/standupService");
 const teamService = require("../../src/services/teamService");
@@ -95,5 +97,19 @@ describe("preview_standup handler", () => {
         todayTasks: "x",
       })
     ).rejects.toThrow(/Invalid date/);
+  });
+
+  it("anchors the lookup date the same way update_standup does", async () => {
+    standupService.getUserResponse.mockResolvedValue(null);
+    await tools.preview_standup({
+      team: "Eng",
+      date: "2026-06-17",
+      todayTasks: "x",
+    });
+    expect(standupService.getUserResponse).toHaveBeenCalledWith(
+      "t1",
+      "user-1",
+      dayjs("2026-06-17", "YYYY-MM-DD").toDate()
+    );
   });
 });

--- a/test/mcp/tools.preview.test.js
+++ b/test/mcp/tools.preview.test.js
@@ -1,0 +1,99 @@
+jest.mock("../../src/config/prisma", () => ({
+  teamMember: { findMany: jest.fn() },
+}));
+jest.mock("../../src/mcp/teamResolver", () => ({ resolveTeam: jest.fn() }));
+jest.mock("../../src/mcp/memberResolver", () => ({ resolveMember: jest.fn() }));
+jest.mock("../../src/utils/permissionHelper", () => ({
+  canManageTeam: jest.fn(),
+}));
+jest.mock("../../src/services/standupService", () => ({
+  submitStandup: jest.fn(),
+  getUserStandupHistory: jest.fn(),
+  getTeamResponses: jest.fn(),
+  getLateResponses: jest.fn(),
+  getActiveMembers: jest.fn(),
+  getUserResponse: jest.fn(),
+  computeIsLate: jest.fn(),
+}));
+jest.mock("../../src/services/teamService", () => ({ getTeamById: jest.fn() }));
+jest.mock("../../src/services/schedulerService", () => ({
+  sendStandupReminders: jest.fn(),
+  sendFollowupReminders: jest.fn(),
+}));
+
+const { resolveTeam } = require("../../src/mcp/teamResolver");
+const standupService = require("../../src/services/standupService");
+const teamService = require("../../src/services/teamService");
+const { buildToolHandlers } = require("../../src/mcp/tools");
+
+const user = { id: "user-1", slackUserId: "U1", name: "Alice" };
+const slackClient = { chat: { postMessage: jest.fn() } };
+const team = { id: "t1", name: "Eng", timezone: "UTC", postingTime: "10:00" };
+
+describe("preview_standup handler", () => {
+  let tools;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resolveTeam.mockResolvedValue({ team: { id: "t1", name: "Eng" } });
+    teamService.getTeamById.mockResolvedValue(team);
+    standupService.computeIsLate.mockReturnValue(false);
+    tools = buildToolHandlers(user, slackClient);
+  });
+
+  it("rejects when all fields are empty", async () => {
+    await expect(tools.preview_standup({ team: "Eng" })).rejects.toThrow(
+      /at least one field/i
+    );
+  });
+
+  it("renders a preview and reports willOverwrite=false when nothing exists", async () => {
+    standupService.getUserResponse.mockResolvedValue(null);
+    const result = await tools.preview_standup({
+      team: "Eng",
+      date: "2026-06-17",
+      yesterdayTasks: "Shipped auth",
+      todayTasks: "Code review",
+    });
+    expect(result.team).toBe("Eng");
+    expect(result.date).toBe("2026-06-17");
+    expect(result.willOverwrite).toBe(false);
+    expect(result.existing).toBeNull();
+    expect(result.fields).toEqual({
+      yesterdayTasks: "Shipped auth",
+      todayTasks: "Code review",
+      blockers: "",
+    });
+    expect(result.preview).toContain("Eng — 2026-06-17");
+    expect(result.preview).toContain("Shipped auth");
+    expect(standupService.submitStandup).not.toHaveBeenCalled();
+  });
+
+  it("reports willOverwrite=true with the existing submission", async () => {
+    standupService.getUserResponse.mockResolvedValue({
+      yesterdayTasks: "Old y",
+      todayTasks: "Old t",
+      blockers: "",
+    });
+    const result = await tools.preview_standup({
+      team: "Eng",
+      date: "2026-06-17",
+      todayTasks: "New plan",
+    });
+    expect(result.willOverwrite).toBe(true);
+    expect(result.existing).toEqual({
+      yesterdayTasks: "Old y",
+      todayTasks: "Old t",
+      blockers: "",
+    });
+  });
+
+  it("rejects an invalid date", async () => {
+    await expect(
+      tools.preview_standup({
+        team: "Eng",
+        date: "06-17-2026",
+        todayTasks: "x",
+      })
+    ).rejects.toThrow(/Invalid date/);
+  });
+});

--- a/test/services/standupService.computeIsLate.test.js
+++ b/test/services/standupService.computeIsLate.test.js
@@ -1,0 +1,41 @@
+// computeIsLate is pure (dayjs + team config). Mock the heavy deps so requiring
+// the service stays offline.
+jest.mock("../../src/config/prisma", () => ({}));
+jest.mock("../../src/services/userService", () => ({}));
+jest.mock("../../src/services/notificationService", () => ({}));
+
+const dayjs = require("dayjs");
+const utc = require("dayjs/plugin/utc");
+const timezone = require("dayjs/plugin/timezone");
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+const standupService = require("../../src/services/standupService");
+
+const team = { timezone: "UTC", postingTime: "10:00" };
+
+describe("standupService.computeIsLate", () => {
+  it("is false for a past date regardless of time", () => {
+    const pastDate = dayjs().utc().subtract(3, "day").toDate();
+    expect(standupService.computeIsLate(team, pastDate)).toBe(false);
+  });
+
+  it("is true for today after the posting time", () => {
+    // Pin 'now' to 23:59 UTC, well past 10:00 posting time.
+    jest.useFakeTimers();
+    jest.setSystemTime(
+      dayjs().utc().startOf("day").hour(23).minute(59).toDate()
+    );
+    try {
+      const lateToday = dayjs()
+        .utc()
+        .startOf("day")
+        .hour(23)
+        .minute(59)
+        .toDate();
+      expect(standupService.computeIsLate(team, lateToday)).toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/test/services/standupService.computeIsLate.test.js
+++ b/test/services/standupService.computeIsLate.test.js
@@ -38,4 +38,16 @@ describe("standupService.computeIsLate", () => {
       jest.useRealTimers();
     }
   });
+
+  it("is false for today before the posting time", () => {
+    // Pin 'now' to 06:00 UTC, before the 10:00 posting time.
+    jest.useFakeTimers();
+    jest.setSystemTime(dayjs().utc().startOf("day").hour(6).toDate());
+    try {
+      const earlyToday = dayjs().utc().startOf("day").hour(6).toDate();
+      expect(standupService.computeIsLate(team, earlyToday)).toBe(false);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });

--- a/web/src/data/mcpDocs.json
+++ b/web/src/data/mcpDocs.json
@@ -183,6 +183,34 @@
           ]
         },
         {
+          "id": "mcp-autodraft",
+          "title": "Let your agent draft your standup",
+          "content": [
+            {
+              "type": "note",
+              "title": "✍️ Draft from your other tools",
+              "value": "If your AI agent is also connected to your work tools (GitHub, Jira, ClickUp, Trello), it can gather what you did and draft your standup for you — then show you a preview and submit only after you confirm. Daily Dose never connects to those tools itself; it relies on the connections your agent already has."
+            },
+            {
+              "type": "text",
+              "value": "**Just ask** — for example: *\"Draft my Engineering standup from my GitHub activity and show me a preview.\"* In clients that support prompts (like Claude Desktop), you can also run the **compose_standup** prompt as a shortcut."
+            },
+            {
+              "type": "command",
+              "command": "preview_standup",
+              "description": "Render a standup draft for a team without saving it. Shows exactly what will be submitted, whether it will overwrite an existing entry, and whether it counts as late — so you can review before confirming.",
+              "examples": [
+                "# Your agent calls this, then shows you the preview and asks:\nReady to submit this standup to Engineering?"
+              ]
+            },
+            {
+              "type": "warning",
+              "title": "You always confirm",
+              "value": "Your agent is instructed to preview and get your explicit yes before submitting, and never to invent work you didn't do. Nothing is written to Daily Dose until you approve it."
+            }
+          ]
+        },
+        {
           "id": "mcp-tools-admin",
           "title": "What you can do — team admins & owners",
           "content": [

--- a/web/src/data/mcpDocs.json
+++ b/web/src/data/mcpDocs.json
@@ -193,7 +193,7 @@
             },
             {
               "type": "text",
-              "value": "**Just ask** — for example: *\"Draft my Engineering standup from my GitHub activity and show me a preview.\"* In clients that support prompts (like Claude Desktop), you can also run the **compose_standup** prompt as a shortcut."
+              "value": "**Just ask** — for example: *“Draft my Engineering standup from my GitHub activity and show me a preview.”* In clients that support prompts (like Claude Desktop), you can also run the **compose_standup** prompt as a shortcut."
             },
             {
               "type": "command",

--- a/web/src/data/mcpDocs.json
+++ b/web/src/data/mcpDocs.json
@@ -57,6 +57,61 @@
           ]
         },
         {
+          "id": "mcp-install",
+          "title": "Step 2 — Install in your coding agent",
+          "content": [
+            {
+              "type": "text",
+              "value": "Pick your client below. Every one connects to the same server URL and signs you in with Slack the first time — there's no token to copy. If your client isn't listed (or doesn't support OAuth sign-in), use the manual-token method in the next section."
+            },
+            {
+              "type": "code",
+              "value": "# MCP server URL\nhttps://dd.jnahian.me/mcp"
+            },
+            {
+              "type": "text",
+              "value": "**Claude Code (CLI)** — add the server, then run `/mcp` inside Claude Code and approve the Slack sign-in in your browser. Add `--scope user` to make it available in every project."
+            },
+            {
+              "type": "code",
+              "value": "claude mcp add --transport http daily-dose https://dd.jnahian.me/mcp\n\n# then, inside Claude Code:\n/mcp"
+            },
+            {
+              "type": "text",
+              "value": "**Claude Desktop** — open **Settings → Connectors → Add custom connector**, paste the server URL, and save. Click the new connector to sign in with Slack."
+            },
+            {
+              "type": "text",
+              "value": "**Cursor** — add this to `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (this project). Cursor opens a browser sign-in on first use and remembers it."
+            },
+            {
+              "type": "code",
+              "value": "{\n  \"mcpServers\": {\n    \"daily-dose\": {\n      \"url\": \"https://dd.jnahian.me/mcp\"\n    }\n  }\n}"
+            },
+            {
+              "type": "text",
+              "value": "**VS Code (GitHub Copilot)** — add this to `.vscode/mcp.json` in your workspace. The root key is `servers` (not `mcpServers`), and you need Copilot **Agent mode** to use the tools."
+            },
+            {
+              "type": "code",
+              "value": "{\n  \"servers\": {\n    \"daily-dose\": {\n      \"type\": \"http\",\n      \"url\": \"https://dd.jnahian.me/mcp\"\n    }\n  }\n}"
+            },
+            {
+              "type": "text",
+              "value": "**Windsurf** — add this to `~/.codeium/windsurf/mcp_config.json`, then refresh MCP servers in Cascade. Windsurf uses `serverUrl` (not `url`)."
+            },
+            {
+              "type": "code",
+              "value": "{\n  \"mcpServers\": {\n    \"daily-dose\": {\n      \"serverUrl\": \"https://dd.jnahian.me/mcp\"\n    }\n  }\n}"
+            },
+            {
+              "type": "note",
+              "title": "🔐 First-use sign-in",
+              "value": "Whichever client you choose, the first request opens a Slack login in your browser. Approve it once and your client keeps the connection fresh automatically — no token to manage. Review or disconnect clients anytime at https://dd.jnahian.me/mcp-tokens"
+            }
+          ]
+        },
+        {
           "id": "mcp-manual-token",
           "title": "Advanced — connect with a manual token",
           "content": [

--- a/web/src/data/mcpDocs.json
+++ b/web/src/data/mcpDocs.json
@@ -193,14 +193,27 @@
             },
             {
               "type": "text",
-              "value": "**Just ask** — for example: *“Draft my Engineering standup from my GitHub activity and show me a preview.”* In clients that support prompts (like Claude Desktop), you can also run the **compose_standup** prompt as a shortcut."
+              "value": "**Just ask, and your agent pulls the details for you.** It reads your recent activity from whatever tools it's connected to — git commits and PRs, Jira, ClickUp, Trello — works out what you did since your last working day and what's on deck today, then drafts the standup. In clients that support prompts (like Claude Desktop), run the **compose_standup** prompt as a one-step shortcut."
+            },
+            {
+              "type": "text",
+              "value": "**Example prompts** — your agent fetches the work itself:"
+            },
+            {
+              "type": "list",
+              "items": [
+                "*“Draft my Engineering standup from my git commits and open PRs, then show me a preview.”*",
+                "*“Pull my in-progress Jira tickets and build today's standup — preview it before submitting.”*",
+                "*“Check my ClickUp tasks and GitHub activity, draft my standup, and ask me to confirm.”*",
+                "*“Summarize the Trello cards I moved yesterday into my standup and let me review it first.”*"
+              ]
             },
             {
               "type": "command",
               "command": "preview_standup",
               "description": "Render a standup draft for a team without saving it. Shows exactly what will be submitted, whether it will overwrite an existing entry, and whether it counts as late — so you can review before confirming.",
               "examples": [
-                "# Your agent calls this, then shows you the preview and asks:\nReady to submit this standup to Engineering?"
+                "# Your agent gathers your work from its connected tools, drafts the\n# three fields, calls preview_standup, then shows you the result and asks:\nHere's your Engineering standup drafted from your GitHub + Jira activity. Submit it?"
               ]
             },
             {


### PR DESCRIPTION
## Summary

Lets an AI agent draft a team member's standup from **its own** work connections (GitHub, Jira, ClickUp, Trello), show a faithful preview, and submit **only after explicit user confirmation**. Daily Dose builds no third-party integrations and stores no external tokens — task-gathering is the agent's job; this PR only adds the preview/confirm tooling and guidance.

### What's added
- **`preview_standup` MCP tool** (read-only): renders a standup draft for a team without saving it, reporting `willOverwrite`/`existing` (the submission it would replace) and `isLate`. Identity-scoped; performs no DB writes. Its `targetDate`/`isLate` are anchored identically to the actual write paths so the preview matches exactly what `submit_standup`/`update_standup` will store.
- **`compose_standup` MCP prompt**: surfaces as a slash-command in supporting clients; walks the agent through resolve-team → gather work → draft → preview → confirm → submit, with hard rules ("never submit without explicit yes", "don't fabricate work").
- **`standupService.computeIsLate(team, standupDate)`**: extracted from `submitStandup` (no behavior change) and reused by `preview_standup`.
- Reworded `submit_standup` description to instruct preview + confirm for clients that don't support prompts.
- Docs: new `/docs/mcp` subsection + `CHANGELOG.md`. Spec & plan under `docs/superpowers/`.

> The user-facing `web/src/data/changelog.json` entry is intentionally deferred to release (folded under the cut version by the `/release` flow).

### Note on commit range
This branch also carries 3 earlier commits that were on local `main` but unpushed: per-agent MCP install docs (`ff8ce3b`), the design spec (`a037369`), and the implementation plan (`b81cf57`).

## Test Plan
- [x] `npm test` — 213/213 pass (29 suites)
- [x] `cd web && npm run build` — succeeds (docs render)
- [x] `preview_standup`: empty-fields rejection, willOverwrite false/true + `existing`, invalid-date rejection, and date-anchoring matches `update_standup`
- [x] `computeIsLate`: past→false, today-after-posting→true, today-before-posting→false
- [x] SDK registration of `preview_standup` tool + `compose_standup` prompt
- [ ] Manual: connect an MCP client, run `compose_standup`, confirm preview shows before any write

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a read-only preview mode for standups—draft and review before submitting
* Enabled AI agents to automatically draft standup content by gathering work from connected tools
* Agents now follow guidance to preview and confirm before final submission

## Documentation
* Added installation instructions for integrating standup tools with popular coding agents
* Added guide for using AI agents to auto-draft standups with work from connected tools

<!-- end of auto-generated comment: release notes by coderabbit.ai -->