### PR TITLE
feat(mcp): advertise server icon to MCP clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- MCP server now advertises a display `title`, `websiteUrl`, and `icons` (32/192/512 PNGs derived from `APP_URL`) on initialize, so MCP clients that support the icons spec show the Daily Dose logo next to the connected server. (`src/mcp/server.js`)
+
 ## [1.14.0] - 2026-06-17
 
 ### Added

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -24,6 +24,39 @@ async function validateMcpToken(req, res, next) {
   }
 }
 
+// Server identity advertised to MCP clients on initialize. Clients that support
+// the MCP icons spec render the icon next to the connected server; the rest
+// ignore it. Icon URLs point at the static assets served from web/dist.
+function mcpServerInfo() {
+  const base = (process.env.APP_URL || "http://localhost:3000").replace(
+    /\/+$/,
+    ""
+  );
+  return {
+    name: "daily-dose-standup",
+    title: "Daily Dose",
+    version: "1.0.0",
+    websiteUrl: "https://dd.jnahian.me",
+    icons: [
+      {
+        src: `${base}/favicon-32x32.png`,
+        mimeType: "image/png",
+        sizes: ["32x32"],
+      },
+      {
+        src: `${base}/android-chrome-192x192.png`,
+        mimeType: "image/png",
+        sizes: ["192x192"],
+      },
+      {
+        src: `${base}/android-chrome-512x512.png`,
+        mimeType: "image/png",
+        sizes: ["512x512"],
+      },
+    ],
+  };
+}
+
 /**
  * Build the POST /mcp handler. `slackApp` is the initialized Bolt app so tools
  * can reach slackApp.client to post to Slack.
@@ -31,10 +64,7 @@ async function validateMcpToken(req, res, next) {
 function createMcpHandler(slackApp) {
   return async function handleMcp(req, res) {
     // Stateless: a fresh server + transport per request, bound to the user.
-    const server = new McpServer({
-      name: "daily-dose-standup",
-      version: "1.0.0",
-    });
+    const server = new McpServer(mcpServerInfo());
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: undefined,
     });
@@ -59,4 +89,4 @@ function createMcpHandler(slackApp) {
   };
 }
 
-module.exports = { validateMcpToken, createMcpHandler };
+module.exports = { validateMcpToken, createMcpHandler, mcpServerInfo };

--- a/test/mcp/server.test.js
+++ b/test/mcp/server.test.js
@@ -27,7 +27,7 @@ jest.mock("../../src/services/schedulerService", () => ({
 
 const { McpServer } = require("@modelcontextprotocol/sdk/server/mcp.js");
 const tokenService = require("../../src/services/mcpTokenService");
-const { validateMcpToken } = require("../../src/mcp/server");
+const { validateMcpToken, mcpServerInfo } = require("../../src/mcp/server");
 const { registerTools } = require("../../src/mcp/tools");
 
 function mockRes() {
@@ -145,5 +145,34 @@ describe("registerTools SDK wiring", () => {
         "send_followup_reminders",
       ])
     );
+  });
+});
+
+describe("mcpServerInfo", () => {
+  const ORIGINAL_APP_URL = process.env.APP_URL;
+  afterEach(() => {
+    process.env.APP_URL = ORIGINAL_APP_URL;
+  });
+
+  it("advertises name, title, website, and PNG icons derived from APP_URL", () => {
+    process.env.APP_URL = "https://dd.example.com/";
+    const info = mcpServerInfo();
+
+    expect(info.name).toBe("daily-dose-standup");
+    expect(info.title).toBe("Daily Dose");
+    expect(info.version).toBe("1.0.0");
+    expect(info.websiteUrl).toBe("https://dd.jnahian.me");
+    expect(info.icons).toHaveLength(3);
+    // Trailing slash on APP_URL must be trimmed (no double slash).
+    expect(info.icons[0].src).toBe("https://dd.example.com/favicon-32x32.png");
+    info.icons.forEach((icon) => {
+      expect(icon.mimeType).toBe("image/png");
+      expect(icon.src).toMatch(/^https:\/\/dd\.example\.com\/[^/]+\.png$/);
+      expect(Array.isArray(icon.sizes)).toBe(true);
+    });
+  });
+
+  it("is accepted by the SDK McpServer constructor", () => {
+    expect(() => new McpServer(mcpServerInfo())).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

The MCP server now advertises its identity to clients on `initialize` — a display **title** ("Daily Dose"), **websiteUrl**, and **icons** — so MCP clients that support the [MCP icons spec](https://modelcontextprotocol.io) render the Daily Dose logo next to the connected server (e.g. in the connectors/servers list).

- `icons` provides three square PNGs (32×32, 192×192, 512×512) so clients can pick the right size.
- Icon `src` URLs are derived from `APP_URL` and point at the existing static assets served from `web/dist/` (`/favicon-32x32.png`, `/android-chrome-192x192.png`, `/android-chrome-512x512.png`).
- No new assets, routes, or dependencies — purely the server-info advertised on connect.

**Caveat:** the icons field is a recent MCP spec addition; clients that don't implement it simply ignore the field (no breakage).

## Test Plan
- [x] `npm test` — 206/206 pass
- [x] New tests: `mcpServerInfo()` returns the expected name/title/website/3 PNG icons with `src` derived from `APP_URL` (trailing slash trimmed), and the SDK `McpServer` constructor accepts the info without throwing
- [ ] Manual: connect the server in a client that renders server icons (e.g. Claude Desktop) and confirm the logo appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)