### PR TITLE
feat(mcp): improve compose_standup task sourcing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - MCP `compose_standup` prompt now tells the agent where to source each field: completed work from finished items (merged PRs, closed/done tickets), today's plan from in-progress/assigned work (open PRs, WIP branches, in-progress/to-do tickets), and blockers — previously it only described gathering completed work. (`src/mcp/tools.js`)
+- MCP `compose_standup` prompt now starts by checking my last submission via `get_my_standup_history`, using its planned `todayTasks` as a checklist and asking which items I completed / for status updates before drafting `yesterdayTasks`. (`src/mcp/tools.js`)
 
 ## [1.15.0] - 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- MCP `compose_standup` prompt now tells the agent where to source each field: completed work from finished items (merged PRs, closed/done tickets), today's plan from in-progress/assigned work (open PRs, WIP branches, in-progress/to-do tickets), and blockers — previously it only described gathering completed work. (`src/mcp/tools.js`)
+
 ## [1.15.0] - 2026-06-17
 
 ### Added

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -46,7 +46,7 @@ function composeStandupPromptText({ team, date } = {}) {
     }`,
     `2. Gather my work${
       date ? ` for ${date}` : ""
-    } using whatever work connections you have (git commits/PRs, ClickUp, Jira, Trello, etc.): what I completed since my last working day, what I plan to do today, and any blockers. Do NOT invent work — if you find nothing, tell me.`,
+    } using whatever work connections you have (git commits/PRs, ClickUp, Jira, Trello, etc.): (a) what I completed since my last working day, from finished work such as merged PRs and closed/done tickets; (b) what I plan to do today, from in-progress and assigned work such as open PRs, work-in-progress branches, and tickets in an in-progress / to-do / assigned state; and (c) any blockers. Do NOT invent work — if a connection turns up nothing for a field, tell me instead of guessing.`,
     "3. Map findings to three fields: yesterdayTasks (completed), todayTasks (planned), and blockers.",
     `4. Call preview_standup with the team${
       date ? `, date ${date},` : ""

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -44,16 +44,17 @@ function composeStandupPromptText({ team, date } = {}) {
         ? ` Use the team "${team}".`
         : " Call list_my_teams; if I belong to more than one team and I haven't named one, ask me which team."
     }`,
-    `2. Gather my work${
+    "2. Check my last standup. Call get_my_standup_history and take my most recent prior submission for this team. Treat what I planned there (its todayTasks) as a checklist of what I expected to finish, and ask me which of those items I completed and for any status updates. Use my answers to seed yesterdayTasks.",
+    `3. Gather my work${
       date ? ` for ${date}` : ""
-    } using whatever work connections you have (git commits/PRs, ClickUp, Jira, Trello, etc.): (a) what I completed since my last working day, from finished work such as merged PRs and closed/done tickets; (b) what I plan to do today, from in-progress and assigned work such as open PRs, work-in-progress branches, and tickets in an in-progress / to-do / assigned state; and (c) any blockers. Do NOT invent work — if a connection turns up nothing for a field, tell me instead of guessing.`,
-    "3. Map findings to three fields: yesterdayTasks (completed), todayTasks (planned), and blockers.",
-    `4. Call preview_standup with the team${
+    } using whatever work connections you have (git commits/PRs, ClickUp, Jira, Trello, etc.): (a) what I completed since my last working day, from finished work such as merged PRs and closed/done tickets — reconciled with the last-standup checklist from step 2; (b) what I plan to do today, from in-progress and assigned work such as open PRs, work-in-progress branches, and tickets in an in-progress / to-do / assigned state; and (c) any blockers. Do NOT invent work — if a connection turns up nothing for a field, tell me instead of guessing.`,
+    "4. Map findings to three fields: yesterdayTasks (completed), todayTasks (planned), and blockers.",
+    `5. Call preview_standup with the team${
       date ? `, date ${date},` : ""
     } and the drafted fields.`,
-    "5. Show me the returned `preview` text verbatim. Warn me if willOverwrite is true (it replaces my existing submission) or isLate is true.",
-    "6. Ask me to confirm. Do NOT submit until I explicitly say yes.",
-    `7. When I confirm, call ${
+    "6. Show me the returned `preview` text verbatim. Warn me if willOverwrite is true (it replaces my existing submission) or isLate is true.",
+    "7. Ask me to confirm. Do NOT submit until I explicitly say yes.",
+    `8. When I confirm, call ${
       date ? "update_standup (with the date)" : "submit_standup"
     } using the same fields. If I ask for changes, revise and preview again.`,
   ].join("\n");


### PR DESCRIPTION
## Summary

Refines the `compose_standup` MCP prompt so the agent sources each standup field from the right place, instead of leaving "today's plan" and "yesterday's completed work" loosely defined.

Two changes (one commit each):

1. **Today's plan from in-progress work** — step explicitly directs the agent to pull `todayTasks` from in-progress/assigned work (open PRs, WIP branches, in-progress/to-do tickets), not just completed work. Completed work is sourced from finished items (merged PRs, closed/done tickets).
2. **Yesterday's work from the last submission** — the prompt now opens by calling `get_my_standup_history`, using the most recent submission's planned `todayTasks` as a checklist and asking which items were completed / for status updates before drafting `yesterdayTasks`. Remaining steps renumbered.

## Notes

- Prompt-text only — affects clients that run the `compose_standup` prompt (e.g. Claude Desktop). No tool/schema changes.
- User-facing `web/src/data/mcpDocs.json` already describes this behavior; only `CHANGELOG.md` updated (per the two-changelog rule).

## Testing

- `npx jest test/mcp/server.test.js -t "compose_standup"` passes (asserts the prompt registers).
- Pre-commit ESLint + Prettier passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)