### PR TITLE
Add self-service token management to admin panel

### DIFF
--- a/docs/admin-panel.md
+++ b/docs/admin-panel.md
@@ -136,6 +136,7 @@ active org.
 | Holidays      | `/admin/holidays`      | CalendarDays    | Org                  |
 | Scheduler     | `/admin/scheduler`     | Clock           | Org                  |
 | Activity      | `/admin/activity`      | Activity        | Org                  |
+| My Tokens     | `/admin/tokens`        | Key             | Self (current user)  |
 
 `AdminLayout` guards every admin route: it shows a loading state while the auth
 context initializes and redirects to `/admin/login` if there is no authenticated
@@ -286,6 +287,20 @@ Read-only feed of the most recent standup submissions for the active org
 plus a localized timestamp. Currently the only activity type is
 `standup_submitted`.
 
+### My Tokens (`/admin/tokens`)
+
+Self-service management of the **logged-in user's own** personal access tokens
+and connected AI clients — the same surface as the public `/mcp-tokens` page, but
+inside the admin panel and keyed off the `admin_session` cookie. These routes are
+**not** org-scoped: they always operate on `req.adminUser`, so any signed-in
+member (super admin, org owner/admin) manages only their own tokens.
+
+- **MCP access tokens**: list (`GET /tokens`), generate (`POST /tokens`, raw value
+  shown once in a modal), and revoke (`DELETE /tokens/:id`). Backed by
+  `mcpTokenService`.
+- **Connected AI clients (OAuth)**: list (`GET /connections`) and disconnect
+  (`DELETE /connections/:clientId`). Backed by `oauthTokenService`.
+
 ---
 
 ## API reference
@@ -324,6 +339,11 @@ super admin, or `OWNER`/`ADMIN` of the target org.
 | GET    | `/standups/:teamId/:date`              | org             | Individual responses                           |
 | GET    | `/scheduler?orgId=`                    | org             | Per-team cron job status                       |
 | GET    | `/activity?orgId=&limit=`              | org             | Recent submissions (max 200)                   |
+| GET    | `/tokens`                              | auth            | List caller's own MCP tokens (no secrets)      |
+| POST   | `/tokens`                              | auth            | Mint caller's MCP token (raw value once)       |
+| DELETE | `/tokens/:id`                          | auth            | Revoke one of the caller's tokens              |
+| GET    | `/connections`                         | auth            | List caller's connected OAuth clients          |
+| DELETE | `/connections/:clientId`               | auth            | Disconnect a client (revoke its grants)        |
 
 Common error responses: `400` (missing/invalid input, e.g. no `orgId`),
 `401` (no/expired session), `403` (not authorized for org / not super admin),

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -6,6 +6,8 @@ const { WebClient } = require("@slack/web-api");
 const slackClient = new WebClient(process.env.BOT_TOKEN);
 const crypto = require("crypto");
 const schedulerService = require("../services/schedulerService");
+const mcpTokenService = require("../services/mcpTokenService");
+const oauthTokenService = require("../mcp/auth/oauthTokenService");
 
 // In-memory OAuth state store (state → expiry timestamp)
 const oauthStates = new Map();
@@ -1161,6 +1163,73 @@ router.get("/activity", requireAuth, async (req, res) => {
   } catch (err) {
     console.error("GET /activity error:", err.message);
     res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// ── Personal access tokens (self-service) ──────────────────────────────
+// These routes are scoped to the logged-in admin user (req.adminUser) and
+// let any signed-in member manage their OWN MCP tokens and OAuth connections
+// from the admin panel — no org/super-admin gate, just an authenticated
+// session. They mirror the public /api/mcp/* surface.
+
+// GET /api/admin/tokens — list the caller's MCP tokens (no secrets)
+router.get("/tokens", requireAuth, async (req, res) => {
+  try {
+    res.json(await mcpTokenService.listTokens(req.adminUser.id));
+  } catch (err) {
+    console.error("GET /tokens error:", err.message);
+    res.status(500).json({ error: "Failed to list tokens" });
+  }
+});
+
+// POST /api/admin/tokens — mint a token (raw value returned ONCE)
+router.post("/tokens", requireAuth, async (req, res) => {
+  try {
+    const name =
+      typeof req.body?.name === "string" ? req.body.name.slice(0, 100) : null;
+    const { rawToken, id, expiresAt } = await mcpTokenService.mintToken(
+      req.adminUser.id,
+      name
+    );
+    res.status(201).json({ id, token: rawToken, expiresAt });
+  } catch (err) {
+    console.error("POST /tokens error:", err.message);
+    res.status(500).json({ error: "Failed to mint token" });
+  }
+});
+
+// DELETE /api/admin/tokens/:id — revoke one of the caller's tokens
+router.delete("/tokens/:id", requireAuth, async (req, res) => {
+  try {
+    await mcpTokenService.revokeToken(req.adminUser.id, req.params.id);
+    res.json({ ok: true });
+  } catch (err) {
+    console.error("DELETE /tokens/:id error:", err.message);
+    res.status(500).json({ error: "Failed to revoke token" });
+  }
+});
+
+// GET /api/admin/connections — list the caller's connected OAuth clients
+router.get("/connections", requireAuth, async (req, res) => {
+  try {
+    res.json(await oauthTokenService.listConnections(req.adminUser.id));
+  } catch (err) {
+    console.error("GET /connections error:", err.message);
+    res.status(500).json({ error: "Failed to list connections" });
+  }
+});
+
+// DELETE /api/admin/connections/:clientId — revoke all grants for one client
+router.delete("/connections/:clientId", requireAuth, async (req, res) => {
+  try {
+    await oauthTokenService.revokeConnection(
+      req.adminUser.id,
+      req.params.clientId
+    );
+    res.json({ ok: true });
+  } catch (err) {
+    console.error("DELETE /connections/:clientId error:", err.message);
+    res.status(500).json({ error: "Failed to revoke connection" });
   }
 });
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -30,6 +30,7 @@ const AdminStandups = lazy(() => import('./pages/admin/Standups'));
 const AdminHolidays = lazy(() => import('./pages/admin/Holidays'));
 const AdminScheduler = lazy(() => import('./pages/admin/Scheduler'));
 const AdminActivity = lazy(() => import('./pages/admin/Activity'));
+const AdminTokens = lazy(() => import('./pages/admin/Tokens'));
 
 function App() {
   const location = useLocation();
@@ -50,6 +51,7 @@ function App() {
             <Route path="holidays" element={<AdminHolidays />} />
             <Route path="scheduler" element={<AdminScheduler />} />
             <Route path="activity" element={<AdminActivity />} />
+            <Route path="tokens" element={<AdminTokens />} />
           </Route>
         </Routes>
       </Suspense>

--- a/web/src/components/admin/AdminSidebar.tsx
+++ b/web/src/components/admin/AdminSidebar.tsx
@@ -1,5 +1,5 @@
 import { NavLink } from 'react-router';
-import { LayoutDashboard, Building2, Users, MessageSquare, CalendarDays, Clock, Activity } from 'lucide-react';
+import { LayoutDashboard, Building2, Users, MessageSquare, CalendarDays, Clock, Activity, Key } from 'lucide-react';
 import { useAdminAuth } from '../../hooks/useAdminAuth';
 
 const navItems = [
@@ -11,6 +11,7 @@ const navItems = [
   { to: '/admin/holidays', icon: CalendarDays, label: 'Holidays' },
   { to: '/admin/scheduler', icon: Clock, label: 'Scheduler' },
   { to: '/admin/activity', icon: Activity, label: 'Activity' },
+  { to: '/admin/tokens', icon: Key, label: 'My Tokens' },
 ];
 
 export function AdminSidebar() {

--- a/web/src/pages/admin/Tokens.tsx
+++ b/web/src/pages/admin/Tokens.tsx
@@ -1,0 +1,271 @@
+import { useEffect, useState } from 'react';
+import { Plus, Trash2, Copy, Check } from 'lucide-react';
+import { DataTable } from '../../components/admin/DataTable';
+import { AdminModal } from '../../components/admin/AdminModal';
+import { StatusBadge } from '../../components/admin/StatusBadge';
+
+interface McpToken {
+  id: string;
+  name: string | null;
+  created_at: string;
+  last_used_at: string | null;
+  expires_at: string | null;
+  revoked_at: string | null;
+}
+
+interface Connection {
+  id: string;
+  clientId: string;
+  clientName: string | null;
+  lastUsedAt: string | null;
+  createdAt: string;
+}
+
+const fmt = (dateStr: string | null) =>
+  dateStr ? new Date(dateStr).toLocaleDateString() : '—';
+
+export default function AdminTokens() {
+  const [tokens, setTokens] = useState<McpToken[]>([]);
+  const [connections, setConnections] = useState<Connection[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const [modal, setModal] = useState<'add' | 'reveal' | 'revoke' | 'disconnect' | null>(null);
+  const [selectedToken, setSelectedToken] = useState<McpToken | null>(null);
+  const [selectedConnection, setSelectedConnection] = useState<Connection | null>(null);
+  const [tokenName, setTokenName] = useState('');
+  const [newToken, setNewToken] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const loadTokens = () => {
+    fetch('/api/admin/tokens', { credentials: 'include' })
+      .then(r => (r.ok ? r.json() : []))
+      .then(setTokens)
+      .catch(() => setError('Failed to load tokens'));
+  };
+
+  const loadConnections = () => {
+    fetch('/api/admin/connections', { credentials: 'include' })
+      .then(r => (r.ok ? r.json() : []))
+      .then((data: Omit<Connection, 'id'>[]) =>
+        setConnections(data.map(c => ({ ...c, id: c.clientId })))
+      )
+      .catch(() => setError('Failed to load connections'));
+  };
+
+  useEffect(() => {
+    loadTokens();
+    loadConnections();
+  }, []);
+
+  const openAdd = () => { setTokenName(''); setNewToken(null); setModal('add'); };
+  const openRevoke = (t: McpToken) => { setSelectedToken(t); setModal('revoke'); };
+  const openDisconnect = (c: Connection) => { setSelectedConnection(c); setModal('disconnect'); };
+
+  const generate = async () => {
+    if (saving) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/admin/tokens', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: tokenName.trim() || undefined }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setNewToken(data.token);
+        setCopied(false);
+        setModal('reveal');
+        loadTokens();
+      } else {
+        setError('Failed to generate token');
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const confirmRevoke = async () => {
+    if (!selectedToken || saving) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/admin/tokens/${selectedToken.id}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      });
+      if (res.ok) loadTokens();
+      setModal(null);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const confirmDisconnect = async () => {
+    if (!selectedConnection || saving) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/admin/connections/${selectedConnection.clientId}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      });
+      if (res.ok) loadConnections();
+      setModal(null);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCopy = () => {
+    if (!newToken) return;
+    navigator.clipboard.writeText(newToken).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <h1 className="text-xl font-semibold text-white">My Tokens</h1>
+        <button
+          onClick={openAdd}
+          className="flex items-center gap-2 px-3 py-2 bg-[#00CFFF] text-black text-sm font-medium rounded-lg hover:bg-[#00CFFF]/90 transition-colors"
+        >
+          <Plus size={15} /> Generate Token
+        </button>
+      </div>
+      <p className="text-sm text-white/50 mb-6">
+        Manage your personal MCP access tokens and connected AI clients.
+      </p>
+
+      {error && <p className="text-red-400 text-sm mb-4">{error}</p>}
+
+      {/* MCP access tokens */}
+      <h2 className="text-sm font-semibold text-white/80 mb-3">MCP access tokens</h2>
+      <DataTable
+        columns={[
+          { key: 'name', label: 'Name', render: (t: McpToken) => t.name || <span className="text-white/40">Unnamed token</span> },
+          {
+            key: 'status', label: 'Status',
+            render: (t: McpToken) => (
+              <StatusBadge variant={t.revoked_at ? 'inactive' : 'active'} label={t.revoked_at ? 'Revoked' : 'Active'} />
+            ),
+          },
+          { key: 'created_at', label: 'Created', render: (t: McpToken) => fmt(t.created_at) },
+          { key: 'last_used_at', label: 'Last used', render: (t: McpToken) => fmt(t.last_used_at) },
+          { key: 'expires_at', label: 'Expires', render: (t: McpToken) => fmt(t.expires_at) },
+          {
+            key: 'actions', label: '',
+            render: (t: McpToken) =>
+              t.revoked_at ? null : (
+                <button
+                  aria-label={`Revoke ${t.name || 'token'}`}
+                  onClick={(e) => { e.stopPropagation(); openRevoke(t); }}
+                  className="text-white/40 hover:text-red-400 transition-colors"
+                >
+                  <Trash2 size={14} />
+                </button>
+              ),
+          },
+        ]}
+        rows={tokens}
+        emptyMessage="No tokens yet. Generate one to connect the Daily Dose MCP server."
+      />
+
+      {/* Connected AI clients (OAuth) */}
+      <h2 className="text-sm font-semibold text-white/80 mt-10 mb-3">Connected AI clients</h2>
+      <p className="text-sm text-white/50 mb-3">
+        Clients connected via Slack sign-in (OAuth). These are separate from the manual tokens above.
+      </p>
+      <DataTable
+        columns={[
+          { key: 'clientName', label: 'Client', render: (c: Connection) => c.clientName || <span className="text-white/40">Unknown client</span> },
+          { key: 'createdAt', label: 'Connected', render: (c: Connection) => fmt(c.createdAt) },
+          { key: 'lastUsedAt', label: 'Last used', render: (c: Connection) => fmt(c.lastUsedAt) },
+          {
+            key: 'actions', label: '',
+            render: (c: Connection) => (
+              <button
+                aria-label={`Disconnect ${c.clientName || 'client'}`}
+                onClick={(e) => { e.stopPropagation(); openDisconnect(c); }}
+                className="text-white/40 hover:text-red-400 transition-colors"
+              >
+                <Trash2 size={14} />
+              </button>
+            ),
+          },
+        ]}
+        rows={connections}
+        emptyMessage="No connected clients yet."
+      />
+
+      {/* Generate modal */}
+      <AdminModal isOpen={modal === 'add'} onClose={() => setModal(null)} title="Generate Token">
+        <div className="space-y-4">
+          <div>
+            <label className="block text-xs text-white/50 mb-1">Token name (optional)</label>
+            <input
+              type="text"
+              value={tokenName}
+              onChange={e => setTokenName(e.target.value)}
+              placeholder="e.g. Claude Desktop"
+              className="w-full bg-[#0d1117] border border-white/10 rounded-lg px-3 py-2 text-sm text-white placeholder-white/30 focus:outline-none focus:border-[#00CFFF]/50"
+            />
+          </div>
+          <div className="flex justify-end gap-3 pt-2">
+            <button onClick={() => setModal(null)} className="px-4 py-2 text-sm text-white/50 hover:text-white transition-colors">Cancel</button>
+            <button onClick={generate} disabled={saving} className="px-4 py-2 text-sm bg-[#00CFFF] text-black font-medium rounded-lg hover:bg-[#00CFFF]/90 transition-colors disabled:opacity-50">{saving ? 'Generating…' : 'Generate'}</button>
+          </div>
+        </div>
+      </AdminModal>
+
+      {/* Reveal modal — shown once */}
+      <AdminModal isOpen={modal === 'reveal'} onClose={() => setModal(null)} title="Your New Token">
+        <div className="space-y-4">
+          <p className="text-sm text-amber-400">
+            Copy this token now — it won't be shown again.
+          </p>
+          <div className="flex gap-2 items-center">
+            <code className="flex-1 px-3 py-2 rounded bg-black/40 text-green-300 text-sm font-mono break-all select-all">
+              {newToken}
+            </code>
+            <button
+              onClick={handleCopy}
+              className="shrink-0 p-2 rounded-lg bg-white/10 hover:bg-white/20 text-white/70 hover:text-white transition-colors"
+              title="Copy to clipboard"
+            >
+              {copied ? <Check className="w-4 h-4 text-green-400" /> : <Copy className="w-4 h-4" />}
+            </button>
+          </div>
+          <div className="flex justify-end pt-2">
+            <button onClick={() => setModal(null)} className="px-4 py-2 text-sm bg-[#00CFFF] text-black font-medium rounded-lg hover:bg-[#00CFFF]/90 transition-colors">Done</button>
+          </div>
+        </div>
+      </AdminModal>
+
+      {/* Revoke modal */}
+      <AdminModal isOpen={modal === 'revoke'} onClose={() => setModal(null)} title="Revoke Token">
+        <p className="text-sm text-white/70 mb-6">
+          Revoke <span className="text-white font-medium">{selectedToken?.name || 'this token'}</span>? Any client using it will lose access immediately. This cannot be undone.
+        </p>
+        <div className="flex justify-end gap-3">
+          <button onClick={() => setModal(null)} className="px-4 py-2 text-sm text-white/50 hover:text-white transition-colors">Cancel</button>
+          <button onClick={confirmRevoke} disabled={saving} className="px-4 py-2 text-sm bg-red-500 text-white font-medium rounded-lg hover:bg-red-600 transition-colors disabled:opacity-50">{saving ? 'Revoking…' : 'Revoke'}</button>
+        </div>
+      </AdminModal>
+
+      {/* Disconnect modal */}
+      <AdminModal isOpen={modal === 'disconnect'} onClose={() => setModal(null)} title="Disconnect Client">
+        <p className="text-sm text-white/70 mb-6">
+          Disconnect <span className="text-white font-medium">{selectedConnection?.clientName || 'this client'}</span>? It will need to sign in again to regain access.
+        </p>
+        <div className="flex justify-end gap-3">
+          <button onClick={() => setModal(null)} className="px-4 py-2 text-sm text-white/50 hover:text-white transition-colors">Cancel</button>
+          <button onClick={confirmDisconnect} disabled={saving} className="px-4 py-2 text-sm bg-red-500 text-white font-medium rounded-lg hover:bg-red-600 transition-colors disabled:opacity-50">{saving ? 'Disconnecting…' : 'Disconnect'}</button>
+        </div>
+      </AdminModal>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Signed-in members can now manage their **own** MCP access tokens and connected AI clients (OAuth) directly from the admin panel, via a new **My Tokens** page. Previously this was only possible on the separate public `/mcp-tokens` page.

This reuses the existing token infrastructure (`mcpTokenService`, `oauthTokenService`) — no new tables or migrations.

## Changes

**Backend** (`src/routes/admin.js`)
- New user-scoped routes under `/api/admin`, gated by `requireAuth` only (no org/super-admin gate) and keyed off `req.adminUser` so each caller only ever touches their own data:
  - `GET /tokens` — list caller's MCP tokens (no secrets)
  - `POST /tokens` — mint a token (raw value returned once)
  - `DELETE /tokens/:id` — revoke a token
  - `GET /connections` — list caller's connected OAuth clients
  - `DELETE /connections/:clientId` — disconnect a client
- Mirrors the existing public `/api/mcp/*` surface.

**Frontend**
- `web/src/pages/admin/Tokens.tsx` — new page: generate/revoke MCP tokens and list/disconnect OAuth clients, styled to match the rest of the admin panel (DataTable, AdminModal, StatusBadge). The raw token is shown once in a copy-to-clipboard modal.
- `web/src/App.tsx` — register the `/admin/tokens` route.
- `web/src/components/admin/AdminSidebar.tsx` — add **My Tokens** nav item (Key icon).

**Docs**
- `docs/admin-panel.md` — document the new page and endpoints. (Per repo convention, admin-panel changes are kept out of both changelogs.)

## Testing

- `cd web && npm run build` — type-checks and builds clean.
- `npm test` — all 29 suites / 215 tests pass.
- ESLint clean on `src/routes/admin.js`.

## Notes

These routes are intentionally **not** org-scoped — they always act on the logged-in user, so a member can only see and revoke their own tokens/connections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgUaTV7pmCynzJbR9xYADn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added self-service management for personal access tokens in the admin panel. Users can now mint new tokens, view active tokens, and revoke them as needed.
  * Added OAuth connection management allowing users to view and disconnect connected AI clients.
  * New "My Tokens" navigation item in the admin sidebar for easy access.

* **Documentation**
  * Updated admin panel documentation with details on the new token and connection management features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->