### PR TITLE
fix: label standup updates as "Standup Updated" not "Late Submission" (#48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Updating an already-submitted standup (via `/dd-standup-update` or MCP `update_standup`) after the team summary has posted now labels the channel thread reply **"🔄 Standup Updated"** instead of **"🕐 Late Submission"**. The thread reply's visible header is driven by the Block Kit blocks, so `createLateResponseBlocks` and `formatLateResponseMessage` now take an `isUpdate` flag that the `submitStandup` late→thread path threads through; the fallback notification text was also corrected (it was previously overridden by the message spread). (`src/utils/blockHelper.js`, `src/services/standupService.js`, #48)
+
 ## [1.15.1] - 2026-06-17
 
 ### Changed

--- a/src/services/standupService.js
+++ b/src/services/standupService.js
@@ -354,7 +354,7 @@ class StandupService {
     };
   }
 
-  async formatLateResponseMessage(response) {
+  async formatLateResponseMessage(response, isUpdate = false) {
     const responseData = {
       userMention: getUserMention(response.user),
       yesterdayTasks: formatTasks(response.yesterdayTasks),
@@ -362,10 +362,12 @@ class StandupService {
       blockers: response.blockers,
     };
 
-    const blocks = createLateResponseBlocks(responseData);
+    const blocks = createLateResponseBlocks(responseData, isUpdate);
 
     return {
-      text: `Late Submission from ${getDisplayName(response.user)}`,
+      text: isUpdate
+        ? `Standup Updated by ${getDisplayName(response.user)}`
+        : `Late Submission from ${getDisplayName(response.user)}`,
       blocks,
     };
   }
@@ -794,14 +796,14 @@ class StandupService {
           todayTasks,
           blockers,
         };
-        const message = await this.formatLateResponseMessage(lateResponse);
+        const message = await this.formatLateResponseMessage(
+          lateResponse,
+          isUpdate
+        );
         await slackClient.chat.postMessage({
           channel: standupPost.channelId,
           thread_ts: standupPost.slackMessageTs,
           reply_broadcast: true,
-          text: isUpdate
-            ? `🔄 *Update* from ${getUserMention(lateResponse.user)}`
-            : `🕐 *Late Submission* of ${getUserMention(lateResponse.user)}`,
           ...message,
         });
       } else {

--- a/src/services/standupService.js
+++ b/src/services/standupService.js
@@ -13,7 +13,7 @@ const {
   getOrgDefaultWorkDays,
 } = require("../utils/dateHelper");
 const { getUserMention, getDisplayName } = require("../utils/userHelper");
-const { formatTasks } = require("../utils/messageHelper");
+const { formatTasks, escapeSlackText } = require("../utils/messageHelper");
 const {
   createSectionBlock,
   createTaskFieldBlocks,
@@ -364,10 +364,12 @@ class StandupService {
 
     const blocks = createLateResponseBlocks(responseData, isUpdate);
 
+    const displayName = escapeSlackText(getDisplayName(response.user));
+
     return {
       text: isUpdate
-        ? `Standup Updated by ${getDisplayName(response.user)}`
-        : `Late Submission from ${getDisplayName(response.user)}`,
+        ? `Standup Updated by ${displayName}`
+        : `Late Submission from ${displayName}`,
       blocks,
     };
   }

--- a/src/utils/blockHelper.js
+++ b/src/utils/blockHelper.js
@@ -437,11 +437,15 @@ function createUserResponseBlocks(response) {
 /**
  * Create late response message blocks
  * @param {object} response - Response object with user data and tasks
+ * @param {boolean} isUpdate - Whether this is an update to an existing submission
+ *   (renders an "Updated" header) rather than a late submission
  * @returns {Array<object>} Array of blocks for late response
  */
-function createLateResponseBlocks(response) {
+function createLateResponseBlocks(response, isUpdate = false) {
   const blocks = [
-    createSectionBlock(`🕐 *Late Submission*`),
+    createSectionBlock(
+      isUpdate ? `🔄 *Standup Updated*` : `🕐 *Late Submission*`
+    ),
     createSectionBlock(`*👤 ${response.userMention}*`),
   ];
 

--- a/test/utils/blockHelper.test.js
+++ b/test/utils/blockHelper.test.js
@@ -88,4 +88,18 @@ describe("blockHelper standup blocks stay within Slack limits", () => {
     expect(fieldsBlock.fields).toHaveLength(2);
     assertWithinSlackLimits(blocks);
   });
+
+  it("createLateResponseBlocks header reflects late vs. update", () => {
+    const response = {
+      userMention: "<@U123>",
+      yesterdayTasks: "did stuff",
+      todayTasks: "will do stuff",
+    };
+
+    const lateHeader = createLateResponseBlocks(response)[0].text.text;
+    expect(lateHeader).toBe("🕐 *Late Submission*");
+
+    const updateHeader = createLateResponseBlocks(response, true)[0].text.text;
+    expect(updateHeader).toBe("🔄 *Standup Updated*");
+  });
 });

--- a/web/src/data/changelog.json
+++ b/web/src/data/changelog.json
@@ -1,9 +1,23 @@
 {
   "versions": [
     {
+      "version": "1.15.2",
+      "date": "2026-06-21",
+      "isLatest": true,
+      "changes": [
+        {
+          "type": "fixed",
+          "title": "Standup updates are now labeled correctly in the channel",
+          "items": [
+            "When you update your standup after the team summary has posted, the thread reply now shows \"🔄 Standup Updated\" instead of being mislabeled \"🕐 Late Submission\""
+          ]
+        }
+      ]
+    },
+    {
       "version": "1.15.0",
       "date": "2026-06-17",
-      "isLatest": true,
+      "isLatest": false,
       "changes": [
         {
           "type": "added",


### PR DESCRIPTION
## Summary

Fixes #48.

When a user updates an already-submitted standup (via `/dd-standup-update` or MCP `update_standup`) **after** the team summary has posted, the thread reply posted to the team channel was mislabeled **"🕐 Late Submission"** instead of indicating an update.

### Root cause

The thread reply's visible header is rendered from the **Block Kit blocks** (`createLateResponseBlocks`), which always hardcoded `🕐 *Late Submission*`. The existing `isUpdate` handling lived only on the message's fallback `text` field — which Slack hides when blocks are present, and which was itself being overridden by the `...message` spread in `postMessage`. So updates always showed the late-submission label.

### Fix

Thread an `isUpdate` flag through the formatting helpers so the late→thread path in `submitStandup` renders the correct header:

- `createLateResponseBlocks(response, isUpdate = false)` — header is `🔄 *Standup Updated*` for updates, `🕐 *Late Submission*` otherwise.
- `formatLateResponseMessage(response, isUpdate = false)` — passes the flag to the blocks and sets a matching fallback `text`.
- `submitStandup` passes `isUpdate` into `formatLateResponseMessage` and drops the now-redundant (overridden) explicit `text`.

Genuine late submissions from other call sites (scheduler, `postLateResponses`, the manual standup script) are unchanged and keep **"🕐 Late Submission"** via the default `isUpdate = false`.

## Testing

- Added a unit test asserting `createLateResponseBlocks` renders the correct header for late vs. update.
- `npm test` — all 216 tests pass.
- `npx eslint` on changed files — clean.

## Changelog

- `CHANGELOG.md` — technical entry under Unreleased → Fixed.
- `web/src/data/changelog.json` — user-facing entry (new `1.15.2` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pfu3F1KnnYZAZM59YrsLoD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pfu3F1KnnYZAZM59YrsLoD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standup update messages now display "🔄 Standup Updated" instead of "🕐 Late Submission" when updating after the team summary has posted.

* **Tests**
  * Added test coverage for standup update message labeling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->