### PR TITLE
feat: auto-provision org Slack channel + auto-invite on team join (#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Auto-provision a per-org `daily-dose-bot` Slack channel on organization creation (`channelService.ensureOrgChannel`, stored on `Organization.botChannelId`). Falls back to `daily-dose-bot-2`, etc. on name conflicts.
+- Auto-invite members to their org's `daily-dose-bot` channel on team join (`/dd-team-join`, team creation, and admin add-member). Best-effort; Slack failures are logged, never blocking.
+- `npm run channels:backfill` (supports `--dry-run`) to create channels and invite current members for existing orgs.
+- Added `channels:manage` bot scope to the Slack manifest (required for channel creation and member invites). Re-install the app to the workspace after updating the manifest.
+
 ## [1.15.2] - 2026-06-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Daily Dose is a Slack bot that automates daily standup meetings for teams. It se
 - **Team Management**: Create and join teams with custom schedules
 - **Leave Management**: Set vacation/leave dates to skip standup reminders
 - **Work Day Configuration**: Customize your working days
-- **Multi-Organization Support**: Supports multiple organizations and workspaces
+- **Multi-Organization Support**: Supports multiple organizations and workspaces; each org gets an auto-created `#daily-dose-bot` channel and members are auto-added when they join a team
 - **Timezone Support**: Each team can have its own timezone
 - **Late Submission Tracking**: Tracks and handles late standup submissions
 
@@ -1034,6 +1034,20 @@ The bot needs these Slack permissions:
 - Post in channels where teams are created
 - Read user information
 - Access slash commands
+- **`channels:manage`** — create the per-org `#daily-dose-bot` channel and invite members automatically
+
+> **Re-install required:** If you update the Slack app manifest to add `channels:manage`, you must re-install the app to the workspace for the new scope to take effect.
+
+### Org Channel Auto-Provisioning
+
+When an organization is created, the bot automatically creates a public `#daily-dose-bot` Slack channel for that org (falling back to `#daily-dose-bot-2`, etc. on name conflicts) and stores its ID on the organization record. Whenever a member joins a team — via `/dd-team-join`, team creation, or admin add-member — they are automatically invited to this channel. The invite is best-effort: Slack failures are logged but never block the join operation.
+
+For existing organizations, run the backfill script to create the channel and invite current members:
+
+```bash
+npm run channels:backfill          # create channels + invite members
+npm run channels:backfill --dry-run  # preview only, no changes
+```
 
 ### Environment Configuration
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Daily Dose is a Slack bot that automates daily standup meetings for teams. It se
 - **Team Management**: Create and join teams with custom schedules
 - **Leave Management**: Set vacation/leave dates to skip standup reminders
 - **Work Day Configuration**: Customize your working days
-- **Multi-Organization Support**: Supports multiple organizations and workspaces; each org gets an auto-created `#daily-dose-bot` channel and members are auto-added when they join a team
+- **Multi-Organization Support**: Supports multiple organizations within the bot's workspace; each org gets an auto-created `#daily-dose-bot` channel and members are auto-added when they join a team
 - **Timezone Support**: Each team can have its own timezone
 - **Late Submission Tracking**: Tracks and handles late standup submissions
 
@@ -1045,8 +1045,8 @@ When an organization is created, the bot automatically creates a public `#daily-
 For existing organizations, run the backfill script to create the channel and invite current members:
 
 ```bash
-npm run channels:backfill          # create channels + invite members
-npm run channels:backfill --dry-run  # preview only, no changes
+npm run channels:backfill             # create channels + invite members
+npm run channels:backfill -- --dry-run  # preview only, no changes
 ```
 
 ### Environment Configuration

--- a/docs/superpowers/plans/2026-06-22-org-channel-auto-provision.md
+++ b/docs/superpowers/plans/2026-06-22-org-channel-auto-provision.md
@@ -1,0 +1,774 @@
+# Org Channel Auto-Provision Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auto-create a per-org `daily-dose-bot` Slack channel when an organization is created, and auto-invite users to their org's channel when they join a team.
+
+**Architecture:** A new best-effort `channelService` wraps the Slack channel API (`conversations.create` / `conversations.invite`) and persists the channel ID on `Organization.botChannelId`. Org creation (admin route) calls `ensureOrgChannel`; all three team-join paths call `inviteUserToOrgChannel`. Every Slack call is best-effort — failures are logged and never roll back the core DB operation. Backfill for existing orgs/members is a separate manual script.
+
+**Tech Stack:** Node.js, Slack Bolt / `@slack/web-api` `WebClient`, Prisma (PostgreSQL/Supabase), Jest.
+
+**Issue:** [#50](https://github.com/jnahian/daily-dose/issues/50) • **Spec:** `docs/superpowers/specs/2026-06-22-org-channel-auto-provision-design.md`
+
+## Global Constraints
+
+- **Best-effort, never blocking:** No Slack channel/invite failure may throw out of `channelService` or roll back org creation / team join. Functions return a value, never throw.
+- **Channel name:** base name is exactly `daily-dose-bot`. On Slack `name_taken`, fall back to `daily-dose-bot-2`, `daily-dose-bot-3`, … (max 5 attempts).
+- **Scope already added:** `channels:manage` is in `slack-app-manifest.json` (covers create + invite). No further scope work in code; the app must be re-installed to the workspace for it to take effect (operational, out of plan).
+- **Slack rate limit:** ~1 req/sec/channel. The backfill script processes orgs and invites sequentially with a delay; never parallelize.
+- **Migrations:** repo uses committed Prisma migrations (`prisma/migrations/`), not bare `db push`.
+- **Changelogs:** this is a user-facing bot behavior → update both `CHANGELOG.md` (technical) and `web/src/data/changelog.json` (user-facing). (The admin-panel UI itself is not the feature; the auto-channel/auto-invite behavior is.)
+
+---
+
+## File Structure
+
+- **Create** `src/services/channelService.js` — best-effort Slack channel wrapper (`ensureOrgChannel`, `inviteUserToOrgChannel`).
+- **Create** `test/services/channelService.test.js` — unit tests for the service.
+- **Create** `test/services/teamServiceChannelInvite.test.js` — verifies join paths call the invite.
+- **Create** `scripts/backfillOrgChannels.js` — one-off backfill for existing orgs/members.
+- **Modify** `prisma/schema.prisma` — add `Organization.botChannelId`.
+- **Create** `prisma/migrations/<ts>_add_org_bot_channel_id/migration.sql` — generated.
+- **Modify** `src/services/teamService.js` — invite on `joinTeam` and `createTeam`.
+- **Modify** `src/routes/admin.js` — `ensureOrgChannel` on org create; invite on `POST /team-members`.
+- **Modify** `package.json` — add `channels:backfill` script alias.
+- **Modify** `CHANGELOG.md`, `web/src/data/changelog.json`, `README.md` — docs.
+
+---
+
+## Task 1: Add `botChannelId` to Organization (schema + migration)
+
+**Files:**
+
+- Modify: `prisma/schema.prisma:11-27` (Organization model)
+- Create: `prisma/migrations/<timestamp>_add_org_bot_channel_id/migration.sql` (generated)
+
+**Interfaces:**
+
+- Produces: `Organization.botChannelId` — nullable `String?`, DB column `bot_channel_id`. Consumed by `channelService` (Task 2/3).
+
+- [ ] **Step 1: Add the column to the schema**
+
+In `prisma/schema.prisma`, inside `model Organization`, add the field after `defaultTimezone` (line 16):
+
+```prisma
+  botChannelId       String?              @map("bot_channel_id")
+```
+
+- [ ] **Step 2: Generate and apply the migration**
+
+Run:
+
+```bash
+npx prisma migrate dev --name add_org_bot_channel_id
+```
+
+Expected: a new folder `prisma/migrations/<timestamp>_add_org_bot_channel_id/` containing `migration.sql` with `ALTER TABLE "organizations" ADD COLUMN "bot_channel_id" TEXT;`, and "Your database is now in sync with your schema."
+
+- [ ] **Step 3: Verify the Prisma client knows the field**
+
+Run:
+
+```bash
+node -e "const p=require('./src/config/prisma'); console.log('bot_channel_id' in p.organization.fields ? 'ok' : (Object.keys(require('@prisma/client').Prisma.OrganizationScalarFieldEnum)))"
+```
+
+Expected: prints `ok` (the `botChannelId`/`bot_channel_id` scalar exists). If it prints the enum list instead, confirm `botChannelId` appears in it.
+
+- [ ] **Step 4: Run the suite to confirm nothing broke**
+
+Run: `npm test`
+Expected: PASS (same baseline as before the change).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add prisma/schema.prisma prisma/migrations
+git commit -m "feat(db): add Organization.botChannelId for org slack channel (#50)"
+```
+
+---
+
+## Task 2: `channelService.ensureOrgChannel`
+
+**Files:**
+
+- Create: `src/services/channelService.js`
+- Test: `test/services/channelService.test.js`
+
+**Interfaces:**
+
+- Consumes: `prisma.organization.update`, `src/utils/logger` (`warn`).
+- Produces: `ensureOrgChannel(client, org) → Promise<string|null>`. `client` is a Slack `WebClient`; `org` is an object with `{ id, botChannelId }`. Returns the channel ID (existing or newly created) or `null` on failure. Idempotent; never throws.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/services/channelService.test.js`:
+
+```js
+jest.mock("../../src/config/prisma", () => ({
+  organization: { update: jest.fn(), findUnique: jest.fn() },
+}));
+jest.mock("../../src/utils/logger", () => ({ warn: jest.fn() }));
+
+const prisma = require("../../src/config/prisma");
+const { ensureOrgChannel } = require("../../src/services/channelService");
+
+function makeClient() {
+  return { conversations: { create: jest.fn(), invite: jest.fn() } };
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("ensureOrgChannel", () => {
+  it("returns the existing channel id without calling Slack", async () => {
+    const client = makeClient();
+    const id = await ensureOrgChannel(client, {
+      id: "o1",
+      botChannelId: "C_OLD",
+    });
+    expect(id).toBe("C_OLD");
+    expect(client.conversations.create).not.toHaveBeenCalled();
+  });
+
+  it("creates the channel and persists the id when none exists", async () => {
+    const client = makeClient();
+    client.conversations.create.mockResolvedValue({
+      ok: true,
+      channel: { id: "C_NEW" },
+    });
+    const id = await ensureOrgChannel(client, { id: "o1", botChannelId: null });
+    expect(client.conversations.create).toHaveBeenCalledWith({
+      name: "daily-dose-bot",
+      is_private: false,
+    });
+    expect(prisma.organization.update).toHaveBeenCalledWith({
+      where: { id: "o1" },
+      data: { botChannelId: "C_NEW" },
+    });
+    expect(id).toBe("C_NEW");
+  });
+
+  it("retries with a suffixed name on name_taken", async () => {
+    const client = makeClient();
+    client.conversations.create
+      .mockRejectedValueOnce({ data: { error: "name_taken" } })
+      .mockResolvedValueOnce({ channel: { id: "C2" } });
+    const id = await ensureOrgChannel(client, { id: "o1", botChannelId: null });
+    expect(client.conversations.create).toHaveBeenNthCalledWith(2, {
+      name: "daily-dose-bot-2",
+      is_private: false,
+    });
+    expect(id).toBe("C2");
+  });
+
+  it("returns null and does not persist on a non-name error", async () => {
+    const client = makeClient();
+    client.conversations.create.mockRejectedValue({
+      data: { error: "missing_scope" },
+    });
+    const id = await ensureOrgChannel(client, { id: "o1", botChannelId: null });
+    expect(id).toBeNull();
+    expect(prisma.organization.update).not.toHaveBeenCalled();
+  });
+
+  it("returns null when client is missing", async () => {
+    expect(
+      await ensureOrgChannel(null, { id: "o1", botChannelId: null })
+    ).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx jest test/services/channelService.test.js`
+Expected: FAIL — `Cannot find module '../../src/services/channelService'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/services/channelService.js`:
+
+```js
+const prisma = require("../config/prisma");
+const logger = require("../utils/logger");
+
+const BASE_CHANNEL_NAME = "daily-dose-bot";
+const MAX_NAME_ATTEMPTS = 5;
+
+/**
+ * Create (or reuse) the org's "daily-dose-bot" Slack channel and persist its
+ * ID on the Organization. Idempotent and best-effort: never throws.
+ * @param {object} client - Slack WebClient
+ * @param {{id: string, botChannelId: ?string}} org
+ * @returns {Promise<string|null>} channel ID, or null on failure
+ */
+async function ensureOrgChannel(client, org) {
+  if (!client || !org) return null;
+  if (org.botChannelId) return org.botChannelId;
+
+  for (let attempt = 1; attempt <= MAX_NAME_ATTEMPTS; attempt++) {
+    const name =
+      attempt === 1 ? BASE_CHANNEL_NAME : `${BASE_CHANNEL_NAME}-${attempt}`;
+    try {
+      const result = await client.conversations.create({
+        name,
+        is_private: false,
+      });
+      const channelId = result.channel.id;
+      await prisma.organization.update({
+        where: { id: org.id },
+        data: { botChannelId: channelId },
+      });
+      return channelId;
+    } catch (err) {
+      if (err.data?.error === "name_taken") continue;
+      logger.warn(
+        `ensureOrgChannel failed for org ${org.id}:`,
+        err.data?.error || err.message
+      );
+      return null;
+    }
+  }
+  logger.warn(`ensureOrgChannel: exhausted name attempts for org ${org.id}`);
+  return null;
+}
+
+module.exports = { ensureOrgChannel };
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx jest test/services/channelService.test.js`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/channelService.js test/services/channelService.test.js
+git commit -m "feat: channelService.ensureOrgChannel for org slack channel (#50)"
+```
+
+---
+
+## Task 3: `channelService.inviteUserToOrgChannel`
+
+**Files:**
+
+- Modify: `src/services/channelService.js`
+- Modify: `test/services/channelService.test.js`
+
+**Interfaces:**
+
+- Consumes: `prisma.organization.findUnique`, `src/utils/logger`.
+- Produces: `inviteUserToOrgChannel(client, orgId, slackUserId) → Promise<boolean>`. Self-fetches the org's `botChannelId` (so callers needn't preload it). Returns `true` if invited or already a member, `false` otherwise. Never throws.
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to `test/services/channelService.test.js` (and add `inviteUserToOrgChannel` to the `require` at the top, i.e. `const { ensureOrgChannel, inviteUserToOrgChannel } = require("../../src/services/channelService");`):
+
+```js
+describe("inviteUserToOrgChannel", () => {
+  it("no-ops and returns false when the org has no channel", async () => {
+    prisma.organization.findUnique.mockResolvedValue({ botChannelId: null });
+    const client = makeClient();
+    const ok = await inviteUserToOrgChannel(client, "o1", "U1");
+    expect(ok).toBe(false);
+    expect(client.conversations.invite).not.toHaveBeenCalled();
+  });
+
+  it("invites the user when the org has a channel", async () => {
+    prisma.organization.findUnique.mockResolvedValue({ botChannelId: "C1" });
+    const client = makeClient();
+    client.conversations.invite.mockResolvedValue({ ok: true });
+    const ok = await inviteUserToOrgChannel(client, "o1", "U1");
+    expect(client.conversations.invite).toHaveBeenCalledWith({
+      channel: "C1",
+      users: "U1",
+    });
+    expect(ok).toBe(true);
+  });
+
+  it("treats already_in_channel as success", async () => {
+    prisma.organization.findUnique.mockResolvedValue({ botChannelId: "C1" });
+    const client = makeClient();
+    client.conversations.invite.mockRejectedValue({
+      data: { error: "already_in_channel" },
+    });
+    expect(await inviteUserToOrgChannel(client, "o1", "U1")).toBe(true);
+  });
+
+  it("returns false on other invite errors", async () => {
+    prisma.organization.findUnique.mockResolvedValue({ botChannelId: "C1" });
+    const client = makeClient();
+    client.conversations.invite.mockRejectedValue({
+      data: { error: "missing_scope" },
+    });
+    expect(await inviteUserToOrgChannel(client, "o1", "U1")).toBe(false);
+  });
+
+  it("returns false when args are missing", async () => {
+    const client = makeClient();
+    expect(await inviteUserToOrgChannel(client, "o1", null)).toBe(false);
+    expect(prisma.organization.findUnique).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx jest test/services/channelService.test.js -t inviteUserToOrgChannel`
+Expected: FAIL — `inviteUserToOrgChannel is not a function`.
+
+- [ ] **Step 3: Add the implementation**
+
+In `src/services/channelService.js`, add the function and export it:
+
+```js
+/**
+ * Invite a user to the org's daily-dose-bot channel. Best-effort: never throws.
+ * Looks up the org's botChannelId itself so callers needn't preload it.
+ * @param {object} client - Slack WebClient
+ * @param {string} orgId
+ * @param {string} slackUserId
+ * @returns {Promise<boolean>} true if invited or already a member
+ */
+async function inviteUserToOrgChannel(client, orgId, slackUserId) {
+  if (!client || !orgId || !slackUserId) return false;
+  try {
+    const org = await prisma.organization.findUnique({
+      where: { id: orgId },
+      select: { botChannelId: true },
+    });
+    if (!org?.botChannelId) return false;
+    await client.conversations.invite({
+      channel: org.botChannelId,
+      users: slackUserId,
+    });
+    return true;
+  } catch (err) {
+    if (err.data?.error === "already_in_channel") return true;
+    logger.warn(
+      `inviteUserToOrgChannel failed (org ${orgId}, user ${slackUserId}):`,
+      err.data?.error || err.message
+    );
+    return false;
+  }
+}
+```
+
+Update the export line to:
+
+```js
+module.exports = { ensureOrgChannel, inviteUserToOrgChannel };
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx jest test/services/channelService.test.js`
+Expected: PASS (10 tests total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/channelService.js test/services/channelService.test.js
+git commit -m "feat: channelService.inviteUserToOrgChannel (#50)"
+```
+
+---
+
+## Task 4: Invite on team join (`teamService.joinTeam` + `createTeam`)
+
+**Files:**
+
+- Modify: `src/services/teamService.js:1-9` (add require), `:104` (createTeam return), `:267-284` (joinTeam upsert/return)
+- Test: `test/services/teamServiceChannelInvite.test.js`
+
+**Interfaces:**
+
+- Consumes: `channelService.inviteUserToOrgChannel(client, orgId, slackUserId)` from Task 3.
+- In `joinTeam`, the org id is `team.organizationId`; the Slack user id is the `slackUserId` parameter; the Slack client is the `slackClient` parameter.
+- In `createTeam`, the org id is `org.id`; the Slack user id is the `slackUserId` parameter; the Slack client is the `slackClient` parameter.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/services/teamServiceChannelInvite.test.js`:
+
+```js
+jest.mock("../../src/config/prisma", () => ({
+  team: { findUnique: jest.fn(), create: jest.fn() },
+  teamMember: { findUnique: jest.fn(), upsert: jest.fn(), create: jest.fn() },
+  $transaction: jest.fn(),
+}));
+jest.mock("../../src/services/userService", () => ({
+  fetchSlackUserData: jest.fn().mockResolvedValue({}),
+  findOrCreateUser: jest.fn(),
+  getUserOrganization: jest.fn(),
+  getOrganizationByWorkspaceId: jest.fn(),
+  addUserToOrganization: jest.fn(),
+  canCreateTeam: jest.fn(),
+}));
+jest.mock("../../src/services/channelService", () => ({
+  inviteUserToOrgChannel: jest.fn().mockResolvedValue(true),
+  ensureOrgChannel: jest.fn(),
+}));
+
+const prisma = require("../../src/config/prisma");
+const userService = require("../../src/services/userService");
+const channelService = require("../../src/services/channelService");
+const teamService = require("../../src/services/teamService");
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  userService.findOrCreateUser.mockResolvedValue({ id: "u1" });
+});
+
+it("joinTeam invites the user to the org channel", async () => {
+  prisma.team.findUnique.mockResolvedValue({
+    id: "t1",
+    organizationId: "o1",
+    organization: { id: "o1" },
+  });
+  userService.getUserOrganization.mockResolvedValue({ id: "o1" });
+  prisma.teamMember.findUnique.mockResolvedValue(null);
+  prisma.teamMember.upsert.mockResolvedValue({ id: "tm1" });
+
+  const client = { conversations: {} };
+  await teamService.joinTeam("U1", "t1", client);
+
+  expect(channelService.inviteUserToOrgChannel).toHaveBeenCalledWith(
+    client,
+    "o1",
+    "U1"
+  );
+});
+
+it("createTeam invites the creator to the org channel", async () => {
+  userService.getUserOrganization.mockResolvedValue({
+    id: "o1",
+    defaultTimezone: "UTC",
+  });
+  userService.canCreateTeam.mockResolvedValue(true);
+  prisma.team.findUnique.mockResolvedValue(null); // no existing team for channel
+  prisma.$transaction.mockImplementation(async (cb) => cb(prisma));
+  prisma.team.create.mockResolvedValue({ id: "t1" });
+  prisma.teamMember.create.mockResolvedValue({});
+
+  const client = { conversations: {} };
+  await teamService.createTeam(
+    "U1",
+    "C1",
+    { name: "Eng", standupTime: "09:30", postingTime: "10:00" },
+    "W1",
+    client
+  );
+
+  expect(channelService.inviteUserToOrgChannel).toHaveBeenCalledWith(
+    client,
+    "o1",
+    "U1"
+  );
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx jest test/services/teamServiceChannelInvite.test.js`
+Expected: FAIL — `inviteUserToOrgChannel` not called (it isn't wired yet).
+
+- [ ] **Step 3: Wire `channelService` into teamService**
+
+In `src/services/teamService.js`, add the require after line 5 (with the other requires):
+
+```js
+const channelService = require("./channelService");
+```
+
+In `joinTeam`, replace the final return (lines 267-284) so the upsert result is captured, the invite fires best-effort, then the member is returned:
+
+```js
+// Add as member
+const member = await prisma.teamMember.upsert({
+  where: {
+    teamId_userId: {
+      teamId: team.id,
+      userId: user.id,
+    },
+  },
+  update: {
+    isActive: true,
+  },
+  create: {
+    teamId: team.id,
+    userId: user.id,
+    role: "MEMBER",
+    isActive: true,
+  },
+});
+
+// Best-effort: add the member to the org's daily-dose-bot channel.
+await channelService.inviteUserToOrgChannel(
+  slackClient,
+  team.organizationId,
+  slackUserId
+);
+
+return member;
+```
+
+In `createTeam`, just before the final `return { team, status, ... }` (line 104), add:
+
+```js
+// Best-effort: add the creator to the org's daily-dose-bot channel.
+await channelService.inviteUserToOrgChannel(slackClient, org.id, slackUserId);
+```
+
+- [ ] **Step 4: Run the new tests + full suite**
+
+Run: `npx jest test/services/teamServiceChannelInvite.test.js && npm test`
+Expected: PASS — both new tests pass and the existing suite (including `teamServiceApproval.test.js`) is green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/teamService.js test/services/teamServiceChannelInvite.test.js
+git commit -m "feat: invite members to org channel on team join (#50)"
+```
+
+---
+
+## Task 5: Provision channel on org creation + invite on admin add-member (`admin.js`)
+
+**Files:**
+
+- Modify: `src/routes/admin.js` — add `channelService` require near the top (alongside the existing `slackClient` WebClient at lines 5-6); call `ensureOrgChannel` in `POST /organizations` (after line 343); add invite in `POST /team-members` (after line 886).
+
+**Interfaces:**
+
+- Consumes: `channelService.ensureOrgChannel(slackClient, org)` and `channelService.inviteUserToOrgChannel(slackClient, orgId, slackUserId)` (Tasks 2-3); the module-level `slackClient` (`new WebClient(process.env.BOT_TOKEN)`).
+
+**Testing note:** `test/routes/admin.test.js` only exercises middleware (`requireAuth`/`requireSuperAdmin`) directly — it has no supertest harness for route handlers, and the handlers aren't exported. Adding one for two best-effort one-liners over an already-unit-tested service is not worth the brittleness. These hooks are verified manually (Step 4) instead. Do not invent a route-handler test harness.
+
+- [ ] **Step 1: Add the require**
+
+In `src/routes/admin.js`, near the top requires (after the `WebClient` setup on lines 5-6), add:
+
+```js
+const channelService = require("../services/channelService");
+```
+
+- [ ] **Step 2: Provision the channel on org creation**
+
+In `POST /organizations`, immediately after `const org = await prisma.organization.create({ ... });` (currently ends line 343) and before `res.status(201).json({`, add:
+
+```js
+// Best-effort: create the org's daily-dose-bot Slack channel.
+await channelService.ensureOrgChannel(slackClient, org);
+```
+
+- [ ] **Step 3: Invite on admin add-member**
+
+In `POST /team-members`, after the `if (existing) { ... } else { ... }` block that sets `teamMember` (currently ends line 886) and before `res.status(201).json({`, add:
+
+```js
+// Best-effort: add the member to the org's daily-dose-bot channel.
+const memberUser = await prisma.user.findUnique({
+  where: { id: userId },
+  select: { slackUserId: true },
+});
+if (memberUser?.slackUserId) {
+  await channelService.inviteUserToOrgChannel(
+    slackClient,
+    team.organizationId,
+    memberUser.slackUserId
+  );
+}
+```
+
+- [ ] **Step 4: Verify wiring (lint + full suite + manual)**
+
+Run: `npm run lint && npm test`
+Expected: PASS, no unused-var or undefined errors; existing `admin.test.js` still green.
+
+Manual (requires the app re-installed with `channels:manage`):
+
+1. In the admin panel, create a new organization → a `daily-dose-bot` channel appears in the workspace; the org row's `bot_channel_id` is populated (check via `npx prisma studio`).
+2. Add a member to a team via the admin panel → that user is added to the `daily-dose-bot` channel.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/routes/admin.js
+git commit -m "feat: provision org channel on create + invite on admin add-member (#50)"
+```
+
+---
+
+## Task 6: Backfill script for existing orgs/members
+
+**Files:**
+
+- Create: `scripts/backfillOrgChannels.js`
+- Modify: `package.json` (scripts section, near the other `*:` aliases around lines 14-24)
+
+**Interfaces:**
+
+- Consumes: `channelService.ensureOrgChannel`, `channelService.inviteUserToOrgChannel`, `prisma`, `logger`, `@slack/web-api` `WebClient`.
+- Produces: `npm run channels:backfill` (with optional `--dry-run`).
+
+- [ ] **Step 1: Write the script**
+
+Create `scripts/backfillOrgChannels.js`:
+
+```js
+#!/usr/bin/env node
+
+require("dotenv").config();
+const { WebClient } = require("@slack/web-api");
+const prisma = require("../src/config/prisma");
+const channelService = require("../src/services/channelService");
+const logger = require("../src/utils/logger");
+
+const DRY_RUN = process.argv.includes("--dry-run");
+const SLEEP_MS = 1200; // Slack ~1 req/sec/channel — stay under the limit.
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function main() {
+  const client = new WebClient(process.env.BOT_TOKEN);
+
+  const orgs = await prisma.organization.findMany({
+    where: { isActive: true },
+    include: {
+      teams: {
+        where: { deletedAt: null },
+        include: {
+          members: {
+            where: { isActive: true },
+            include: { user: true },
+          },
+        },
+      },
+    },
+  });
+
+  logger.info(`Backfill${DRY_RUN ? " (dry-run)" : ""}: ${orgs.length} org(s)`);
+
+  for (const org of orgs) {
+    logger.info(`Org "${org.name}" (${org.id})`);
+
+    let channelId = org.botChannelId;
+    if (!channelId) {
+      if (DRY_RUN) {
+        logger.info("  [dry-run] would create daily-dose-bot channel");
+      } else {
+        channelId = await channelService.ensureOrgChannel(client, org);
+        await sleep(SLEEP_MS);
+        if (!channelId) {
+          logger.warn("  could not create channel; skipping invites");
+          continue;
+        }
+      }
+    }
+
+    const slackUserIds = new Set();
+    for (const team of org.teams) {
+      for (const m of team.members) {
+        if (m.user?.slackUserId) slackUserIds.add(m.user.slackUserId);
+      }
+    }
+
+    for (const uid of slackUserIds) {
+      if (DRY_RUN) {
+        logger.info(`  [dry-run] would invite ${uid}`);
+        continue;
+      }
+      await channelService.inviteUserToOrgChannel(client, org.id, uid);
+      await sleep(SLEEP_MS);
+    }
+    logger.info(`  ${slackUserIds.size} member(s) processed`);
+  }
+
+  logger.info("Backfill complete.");
+}
+
+main()
+  .catch((err) => {
+    logger.error("Backfill failed:", err.message);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());
+```
+
+- [ ] **Step 2: Add the npm alias**
+
+In `package.json`, add to the `scripts` block (next to the other aliases):
+
+```json
+    "channels:backfill": "node scripts/backfillOrgChannels.js",
+```
+
+- [ ] **Step 3: Verify the script loads and dry-run works**
+
+Run: `npm run channels:backfill -- --dry-run`
+Expected: it connects, lists each active org, and logs `[dry-run] would create…` / `[dry-run] would invite…` lines with no Slack writes and no thrown errors. (Requires a valid `BOT_TOKEN` and DB connection in `.env`.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/backfillOrgChannels.js package.json
+git commit -m "feat: add channels:backfill script for existing orgs (#50)"
+```
+
+---
+
+## Task 7: Documentation (changelogs + README)
+
+**Files:**
+
+- Modify: `CHANGELOG.md` (technical, under Unreleased/next version)
+- Modify: `web/src/data/changelog.json` (user-facing)
+- Modify: `README.md` (behavior + scope note)
+
+- [ ] **Step 1: Update `CHANGELOG.md`**
+
+Add an entry under the top `## [Unreleased]` section (create the section if absent), e.g.:
+
+```markdown
+### Added
+
+- Auto-provision a per-org `daily-dose-bot` Slack channel on organization creation (`channelService.ensureOrgChannel`, stored on `Organization.botChannelId`).
+- Auto-invite members to their org's `daily-dose-bot` channel on team join (`/dd-team-join`, team creation, and admin add-member). Best-effort; failures are logged, never blocking.
+- `npm run channels:backfill` (supports `--dry-run`) to create channels and invite current members for existing orgs.
+- Added `channels:manage` bot scope to the Slack manifest.
+```
+
+- [ ] **Step 2: Update `web/src/data/changelog.json`**
+
+Add a user-facing entry (match the existing JSON shape — inspect the first entry in the file and mirror its keys/format). Plain-language summary, no internal names:
+
+> Your organization now gets a dedicated **#daily-dose-bot** channel automatically, and new team members are added to it when they join — so everyone lands in one shared space without any manual setup.
+
+- [ ] **Step 3: Update `README.md`**
+
+In the relevant features / Slack-setup section, note that orgs get an auto-created `daily-dose-bot` channel and members are auto-added on team join, and that the bot now requires the `channels:manage` scope (re-install the app after updating the manifest).
+
+- [ ] **Step 4: Verify the JSON is valid**
+
+Run: `node -e "require('./web/src/data/changelog.json'); console.log('valid json')"`
+Expected: prints `valid json`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CHANGELOG.md web/src/data/changelog.json README.md
+git commit -m "docs: changelog + readme for org channel auto-provision (#50)"
+```
+
+---
+
+## Self-Review (completed during authoring)
+
+- **Spec coverage:** data model (T1), `channelService` create/invite (T2/T3), org-create hook + admin add-member hook (T5), team-join hooks (T4), scopes (already committed; documented in T7), backfill script (T6), error handling (best-effort in every service function), testing (T2-T4), documentation (T7). All spec sections map to a task.
+- **Type/name consistency:** `ensureOrgChannel(client, org)` and `inviteUserToOrgChannel(client, orgId, slackUserId)` are used with identical signatures across T4-T6. `botChannelId` / `bot_channel_id` consistent between T1 and the service. Channel name `daily-dose-bot` consistent everywhere.
+- **Placeholders:** none — every code/test step contains full content.
+- **Known testing boundary (intentional):** admin-route hooks (T5) are verified by lint + manual steps, not a new supertest harness, because the existing route tests don't exercise handlers and the wiring is a thin call over the unit-tested service.

--- a/docs/superpowers/plans/2026-06-22-org-channel-auto-provision.md
+++ b/docs/superpowers/plans/2026-06-22-org-channel-auto-provision.md
@@ -55,32 +55,42 @@ In `prisma/schema.prisma`, inside `model Organization`, add the field after `def
   botChannelId       String?              @map("bot_channel_id")
 ```
 
-- [ ] **Step 2: Generate and apply the migration**
+- [ ] **Step 2: STOP — confirm the migration workflow with the user before running anything**
 
-Run:
+Repo policy (CLAUDE.md): "Confirm with the user before generating a new migration vs. pushing; don't mix the two workflows." **Do not run a migration command autonomously.** Ask the user:
+
+- Generate a committed migration (repo's documented workflow) or `db push`?
+- **Which database does `DIRECT_URL` point at?** `prisma migrate dev` is a _development_ command — on detecting drift it prompts to **reset (drop) the database**. It must only ever run against a throwaway/dev DB, never production Supabase. If `DIRECT_URL` is production, generate the migration with `--create-only` against a dev DB and apply with `npx prisma migrate deploy` (no reset), or have the user run it.
+
+Do not proceed past this step without an explicit answer.
+
+- [ ] **Step 3: Generate the migration (per the user's answer in Step 2)**
+
+If the user chose the migration workflow against a safe dev DB:
 
 ```bash
 npx prisma migrate dev --name add_org_bot_channel_id
 ```
 
-Expected: a new folder `prisma/migrations/<timestamp>_add_org_bot_channel_id/` containing `migration.sql` with `ALTER TABLE "organizations" ADD COLUMN "bot_channel_id" TEXT;`, and "Your database is now in sync with your schema."
+Expected: a new folder `prisma/migrations/<timestamp>_add_org_bot_channel_id/` containing `migration.sql` with an `ALTER TABLE "organizations" ADD COLUMN "bot_channel_id"` statement; `npx prisma generate` runs automatically.
 
-- [ ] **Step 3: Verify the Prisma client knows the field**
+- [ ] **Step 4: Verify the migration SQL and regenerated client**
 
 Run:
 
 ```bash
-node -e "const p=require('./src/config/prisma'); console.log('bot_channel_id' in p.organization.fields ? 'ok' : (Object.keys(require('@prisma/client').Prisma.OrganizationScalarFieldEnum)))"
+grep -ri "bot_channel_id" prisma/migrations/*add_org_bot_channel_id*/migration.sql
+node -e "require('@prisma/client').Prisma.dmmf.datamodel.models.find(m=>m.name==='Organization').fields.some(f=>f.name==='botChannelId') ? console.log('client ok') : process.exit(1)"
 ```
 
-Expected: prints `ok` (the `botChannelId`/`bot_channel_id` scalar exists). If it prints the enum list instead, confirm `botChannelId` appears in it.
+Expected: `grep` prints the `ADD COLUMN ... bot_channel_id` line, and the node check prints `client ok` (exit 0). If the node check exits non-zero, run `npx prisma generate` and retry.
 
-- [ ] **Step 4: Run the suite to confirm nothing broke**
+- [ ] **Step 5: Run the suite to confirm nothing broke**
 
 Run: `npm test`
 Expected: PASS (same baseline as before the change).
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
 git add prisma/schema.prisma prisma/migrations
@@ -593,7 +603,8 @@ Expected: PASS, no unused-var or undefined errors; existing `admin.test.js` stil
 Manual (requires the app re-installed with `channels:manage`):
 
 1. In the admin panel, create a new organization → a `daily-dose-bot` channel appears in the workspace; the org row's `bot_channel_id` is populated (check via `npx prisma studio`).
-2. Add a member to a team via the admin panel → that user is added to the `daily-dose-bot` channel.
+2. Add a member to a team via the admin panel → that user is added to the `daily-dose-bot` channel. This is the single riskiest real-Slack assumption (unit tests mock it): confirm the bot can actually `conversations.invite` into the channel it created — it should, since it joins as the channel creator. If invites fail with `not_in_channel`, the bot must `conversations.join` the channel first; add that to `ensureOrgChannel` only if observed.
+3. Repeat the team-join check via `/dd-team-join` in Slack to cover the slash-command path.
 
 - [ ] **Step 5: Commit**
 
@@ -742,9 +753,11 @@ Add an entry under the top `## [Unreleased]` section (create the section if abse
 - Added `channels:manage` bot scope to the Slack manifest.
 ```
 
-- [ ] **Step 2: Update `web/src/data/changelog.json`**
+- [ ] **Step 2: Update `web/src/data/changelog.json`** (confirm with user first)
 
-Add a user-facing entry (match the existing JSON shape — inspect the first entry in the file and mirror its keys/format). Plain-language summary, no internal names:
+Note: the org-creation trigger lives in the admin panel, and repo rules keep admin-panel work out of both changelogs ([[feedback_admin_panel_no_changelog]]). This entry is justified only because the _user-visible behavior_ (a channel appears; team members land in it via `/dd-team-join`) is a bot feature, not an admin-panel feature. **Confirm with the user that they want this `changelog.json` entry** before adding it; if they decline, skip this step and keep the change in `CHANGELOG.md` only.
+
+If confirmed, add a user-facing entry (match the existing JSON shape — inspect the first entry in the file and mirror its keys/format). Frame it around the user-visible effect, never the admin action:
 
 > Your organization now gets a dedicated **#daily-dose-bot** channel automatically, and new team members are added to it when they join — so everyone lands in one shared space without any manual setup.
 

--- a/docs/superpowers/specs/2026-06-22-org-channel-auto-provision-design.md
+++ b/docs/superpowers/specs/2026-06-22-org-channel-auto-provision-design.md
@@ -1,0 +1,114 @@
+# Auto-provision org Slack channel + auto-invite on team join
+
+**Issue:** [#50](https://github.com/jnahian/daily-dose/issues/50)
+**Date:** 2026-06-22
+**Status:** Approved — ready for implementation plan
+
+## Goal
+
+1. When an organization is created (admin panel), automatically create a public Slack channel named `daily-dose-bot` for that org.
+2. When a user joins a team, automatically invite them to their org's `daily-dose-bot` channel.
+
+## Context (current behavior)
+
+- **Org creation** happens in exactly one place: `POST /api/admin/organizations` (`src/routes/admin.js`), super-admin only. No auto-creation on workspace join.
+- **TeamMember creation** happens in three places:
+  - `teamService.joinTeam()` — `/dd-team-join` slash command (also auto-adds the user to the org).
+  - `teamService` team-creation path — creator added as `ADMIN`.
+  - `POST /api/admin/team-members` (`src/routes/admin.js`) — admin adds a member.
+- **Slack client access**: Bolt handlers receive `client`; services use `this.app.client`; `src/routes/admin.js` has its own `WebClient` (`slackClient`) built from `BOT_TOKEN`.
+- **Bot is single-workspace** (`BOT_TOKEN`); DB schema is multi-tenant. Channels are always created in the bot's installed workspace.
+- **Current scopes** lack channel management — only `channels:read`. Need to add scopes and re-install.
+
+## Design decisions
+
+| Decision         | Choice                                                                                                                                                           |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Channel naming   | Per-org channel named `daily-dose-bot`; on `name_taken` collision, fall back to a slugged suffix (`daily-dose-bot-2`, …). Store the resolved channel ID per org. |
+| Backfill         | Forward-only. New orgs get a channel; new joins get invited. Existing orgs/members untouched — a separate one-off script backfills later.                        |
+| Failure handling | Best-effort: log Slack failures, never roll back org creation or team join.                                                                                      |
+
+## Architecture
+
+### 1. Data model
+
+Add a nullable column to `Organization`:
+
+- `botChannelId String?` — Slack channel ID (e.g. `C0XXXX`) of the org's `daily-dose-bot` channel. Null until created.
+
+Requires a **Prisma migration** (repo uses committed migrations). Confirm migration-vs-push with the user before running.
+
+### 2. New module: `src/services/channelService.js`
+
+Single-purpose, best-effort wrapper around the Slack channel API. Accepts a Slack `client` as a parameter so it works from both Bolt handlers and the admin route's `WebClient`.
+
+- `ensureOrgChannel(client, org)` — idempotent.
+  - If `org.botChannelId` is set, return it.
+  - Else `conversations.create({ name: "daily-dose-bot" })`. On `name_taken`, retry with suffix (`daily-dose-bot-2`, `-3`, …) up to a small bound.
+  - Persist resulting channel ID to `org.botChannelId`.
+  - Bot is auto-added as channel creator.
+  - Returns the channel ID (or `null` on failure).
+- `inviteUserToOrgChannel(client, org, slackUserId)` — best-effort.
+  - No-op if `org.botChannelId` is null.
+  - `conversations.invite({ channel, users: slackUserId })`.
+  - Swallow `already_in_channel`.
+
+Both functions wrap every Slack call in try/catch, log failures as warnings via the existing logger, and never throw to the caller.
+
+### 3. Hook points
+
+- **Org creation** — after `prisma.organization.create` in `POST /api/admin/organizations`, call `ensureOrgChannel(slackClient, org)`.
+- **Team join** — call `inviteUserToOrgChannel` from all three entry points:
+  - `teamService.joinTeam()`
+  - team-creation path (creator)
+  - `POST /api/admin/team-members`
+
+  Each needs the user's `slackUserId` and the team's organization (load `org` with `botChannelId`). All wrapped best-effort.
+
+### 4. Slack scopes
+
+Add to `slack-app-manifest.json` and `scripts/updateSlackManifest.js`:
+
+- `channels:manage` — create public channels.
+- `channels:invite` — invite users to channels.
+
+Operational: re-install / re-authorize the app to the workspace after the scope change. Document in the implementation steps.
+
+### 5. Backfill script
+
+`scripts/backfillOrgChannels.js` (one-off, run manually):
+
+- For each org without `botChannelId`: `ensureOrgChannel`.
+- For each active TeamMember in the org: `inviteUserToOrgChannel`.
+- Process orgs/teams **sequentially** (Slack rate-limits ~1 req/sec/channel). Add a small delay between invite batches.
+- Support `--dry-run`.
+
+Add an `npm run` alias consistent with existing script conventions.
+
+## Error handling
+
+- All Slack channel/invite calls are best-effort and logged; they never block the core DB operation.
+- `ensureOrgChannel` collision fallback bounded to a few attempts; if all fail, log and leave `botChannelId` null (next attempt / backfill can retry).
+- `inviteUserToOrgChannel` swallows `already_in_channel`; other errors logged.
+
+## Testing
+
+- Unit tests for `channelService` with a mocked Slack `client`:
+  - creates channel and persists ID when `botChannelId` null.
+  - returns existing ID when already set (idempotent, no API call).
+  - retries with suffix on `name_taken`.
+  - invite no-ops when no channel; swallows `already_in_channel`; logs other errors.
+- Manual Slack verification: create an org in admin panel → channel appears; join a team → user invited.
+
+## Out of scope
+
+- Auto-creating orgs on workspace join (unchanged — admin-panel only).
+- Archiving/renaming channels when orgs are deleted/renamed.
+- Private channels.
+
+## Documentation
+
+- `CHANGELOG.md`: record the feature (technical).
+- `web/src/data/changelog.json`: user-facing entry (auto-channel + auto-invite).
+- Admin-panel behavior itself stays out of changelogs per repo rules, but the org-channel/team-join feature is a user-facing bot behavior, so it belongs in both changelogs.
+- Update `README.md` for new scopes / behavior if applicable.

--- a/docs/superpowers/specs/2026-06-22-org-channel-auto-provision-design.md
+++ b/docs/superpowers/specs/2026-06-22-org-channel-auto-provision-design.md
@@ -67,12 +67,13 @@ Both functions wrap every Slack call in try/catch, log failures as warnings via 
 
 ### 4. Slack scopes
 
-Add to `slack-app-manifest.json` and `scripts/updateSlackManifest.js`:
+Add **one** bot scope to `slack-app-manifest.json`:
 
-- `channels:manage` — create public channels.
-- `channels:invite` — invite users to channels.
+- `channels:manage` — covers both `conversations.create` (create public channel) **and** `conversations.invite` (invite users to a public channel). Verified against Slack docs: `channels:manage` appears in the required-scope list for both methods, so no separate invite scope is needed.
 
-Operational: re-install / re-authorize the app to the workspace after the scope change. Document in the implementation steps.
+`scripts/updateSlackManifest.js` reads scopes directly from `slack-app-manifest.json` (no hardcoded list), so the manifest edit is sufficient.
+
+Operational: re-install / re-authorize the app to the workspace after the scope change (`npm run manifest:update`, then reinstall). Document in the implementation steps.
 
 ### 5. Backfill script
 

--- a/docs/superpowers/specs/2026-06-22-org-channel-auto-provision-design.md
+++ b/docs/superpowers/specs/2026-06-22-org-channel-auto-provision-design.md
@@ -48,8 +48,8 @@ Single-purpose, best-effort wrapper around the Slack channel API. Accepts a Slac
   - Persist resulting channel ID to `org.botChannelId`.
   - Bot is auto-added as channel creator.
   - Returns the channel ID (or `null` on failure).
-- `inviteUserToOrgChannel(client, org, slackUserId)` — best-effort.
-  - No-op if `org.botChannelId` is null.
+- `inviteUserToOrgChannel(client, orgId, slackUserId)` — best-effort.
+  - Looks up the org internally by `orgId`; no-op if its `botChannelId` is null.
   - `conversations.invite({ channel, users: slackUserId })`.
   - Swallow `already_in_channel`.
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "slack:info": "node scripts/viewSlackTeamInfo.js",
     "team:members": "node scripts/check-team-members.js",
     "team:promote": "node scripts/promoteTeamMember.js",
+    "channels:backfill": "node scripts/backfillOrgChannels.js",
     "debug:scheduler": "node scripts/debugScheduler.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/prisma/migrations/20260622044353_add_org_bot_channel_id/migration.sql
+++ b/prisma/migrations/20260622044353_add_org_bot_channel_id/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."organizations" ADD COLUMN     "bot_channel_id" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,6 +14,7 @@ model Organization {
   slackWorkspaceId   String?              @unique @map("slack_workspace_id")
   slackWorkspaceName String?              @map("slack_workspace_name")
   defaultTimezone    String               @default("America/New_York") @map("default_timezone")
+  botChannelId       String?              @map("bot_channel_id")
   settings           Json                 @default("{}")
   isActive           Boolean              @default(true) @map("is_active")
   createdAt          DateTime             @default(now()) @map("created_at")

--- a/scripts/backfillOrgChannels.js
+++ b/scripts/backfillOrgChannels.js
@@ -11,6 +11,11 @@ const SLEEP_MS = 1200; // Slack ~1 req/sec/channel — stay under the limit.
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 async function main() {
+  if (!process.env.BOT_TOKEN) {
+    logger.error("Backfill failed: BOT_TOKEN is required.");
+    process.exitCode = 1;
+    return;
+  }
   const client = new WebClient(process.env.BOT_TOKEN);
 
   const orgs = await prisma.organization.findMany({

--- a/scripts/backfillOrgChannels.js
+++ b/scripts/backfillOrgChannels.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+require("dotenv").config();
+const { WebClient } = require("@slack/web-api");
+const prisma = require("../src/config/prisma");
+const channelService = require("../src/services/channelService");
+const logger = require("../src/utils/logger");
+
+const DRY_RUN = process.argv.includes("--dry-run");
+const SLEEP_MS = 1200; // Slack ~1 req/sec/channel — stay under the limit.
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function main() {
+  const client = new WebClient(process.env.BOT_TOKEN);
+
+  const orgs = await prisma.organization.findMany({
+    where: { isActive: true },
+    include: {
+      teams: {
+        where: { deletedAt: null },
+        include: {
+          members: {
+            where: { isActive: true },
+            include: { user: true },
+          },
+        },
+      },
+    },
+  });
+
+  logger.info(`Backfill${DRY_RUN ? " (dry-run)" : ""}: ${orgs.length} org(s)`);
+
+  for (const org of orgs) {
+    logger.info(`Org "${org.name}" (${org.id})`);
+
+    let channelId = org.botChannelId;
+    if (!channelId) {
+      if (DRY_RUN) {
+        logger.info("  [dry-run] would create daily-dose-bot channel");
+      } else {
+        channelId = await channelService.ensureOrgChannel(client, org);
+        await sleep(SLEEP_MS);
+        if (!channelId) {
+          logger.warn("  could not create channel; skipping invites");
+          continue;
+        }
+      }
+    }
+
+    const slackUserIds = new Set();
+    for (const team of org.teams) {
+      for (const m of team.members) {
+        if (m.user?.slackUserId) slackUserIds.add(m.user.slackUserId);
+      }
+    }
+
+    for (const uid of slackUserIds) {
+      if (DRY_RUN) {
+        logger.info(`  [dry-run] would invite ${uid}`);
+        continue;
+      }
+      await channelService.inviteUserToOrgChannel(client, org.id, uid);
+      await sleep(SLEEP_MS);
+    }
+    logger.info(`  ${slackUserIds.size} member(s) processed`);
+  }
+
+  logger.info("Backfill complete.");
+}
+
+main()
+  .catch((err) => {
+    logger.error("Backfill failed:", err.message);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/slack-app-manifest.json
+++ b/slack-app-manifest.json
@@ -242,6 +242,7 @@
       "user": ["identity.basic", "identity.email"],
       "bot": [
         "channels:read",
+        "channels:manage",
         "chat:write",
         "chat:write.public",
         "commands",

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -7,6 +7,7 @@ const slackClient = new WebClient(process.env.BOT_TOKEN);
 const crypto = require("crypto");
 const schedulerService = require("../services/schedulerService");
 const mcpTokenService = require("../services/mcpTokenService");
+const channelService = require("../services/channelService");
 const oauthTokenService = require("../mcp/auth/oauthTokenService");
 
 // In-memory OAuth state store (state → expiry timestamp)
@@ -341,6 +342,8 @@ router.post(
           defaultTimezone: defaultTimezone?.trim() || "America/New_York",
         },
       });
+      // Best-effort: create the org's daily-dose-bot Slack channel.
+      await channelService.ensureOrgChannel(slackClient, org);
       res.status(201).json({
         id: org.id,
         name: org.name,
@@ -883,6 +886,19 @@ router.post("/team-members", requireAuth, async (req, res) => {
       teamMember = await prisma.teamMember.create({
         data: { teamId, userId, role: role || "MEMBER", isActive: true },
       });
+    }
+
+    // Best-effort: add the member to the org's daily-dose-bot channel.
+    const memberUser = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { slackUserId: true },
+    });
+    if (memberUser?.slackUserId) {
+      await channelService.inviteUserToOrgChannel(
+        slackClient,
+        team.organizationId,
+        memberUser.slackUserId
+      );
     }
 
     res.status(201).json({

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -889,15 +889,22 @@ router.post("/team-members", requireAuth, async (req, res) => {
     }
 
     // Best-effort: add the member to the org's daily-dose-bot channel.
-    const memberUser = await prisma.user.findUnique({
-      where: { id: userId },
-      select: { slackUserId: true },
-    });
-    if (memberUser?.slackUserId) {
-      await channelService.inviteUserToOrgChannel(
-        slackClient,
-        team.organizationId,
-        memberUser.slackUserId
+    try {
+      const memberUser = await prisma.user.findUnique({
+        where: { id: userId },
+        select: { slackUserId: true },
+      });
+      if (memberUser?.slackUserId) {
+        await channelService.inviteUserToOrgChannel(
+          slackClient,
+          team.organizationId,
+          memberUser.slackUserId
+        );
+      }
+    } catch (channelErr) {
+      console.error(
+        "POST /team-members channel invite (best-effort) failed:",
+        channelErr.message
       );
     }
 

--- a/src/services/channelService.js
+++ b/src/services/channelService.js
@@ -1,0 +1,45 @@
+const prisma = require("../config/prisma");
+const logger = require("../utils/logger");
+
+const BASE_CHANNEL_NAME = "daily-dose-bot";
+const MAX_NAME_ATTEMPTS = 5;
+
+/**
+ * Create (or reuse) the org's "daily-dose-bot" Slack channel and persist its
+ * ID on the Organization. Idempotent and best-effort: never throws.
+ * @param {object} client - Slack WebClient
+ * @param {{id: string, botChannelId: ?string}} org
+ * @returns {Promise<string|null>} channel ID, or null on failure
+ */
+async function ensureOrgChannel(client, org) {
+  if (!client || !org) return null;
+  if (org.botChannelId) return org.botChannelId;
+
+  for (let attempt = 1; attempt <= MAX_NAME_ATTEMPTS; attempt++) {
+    const name =
+      attempt === 1 ? BASE_CHANNEL_NAME : `${BASE_CHANNEL_NAME}-${attempt}`;
+    try {
+      const result = await client.conversations.create({
+        name,
+        is_private: false,
+      });
+      const channelId = result.channel.id;
+      await prisma.organization.update({
+        where: { id: org.id },
+        data: { botChannelId: channelId },
+      });
+      return channelId;
+    } catch (err) {
+      if (err.data?.error === "name_taken") continue;
+      logger.warn(
+        `ensureOrgChannel failed for org ${org.id}:`,
+        err.data?.error || err.message
+      );
+      return null;
+    }
+  }
+  logger.warn(`ensureOrgChannel: exhausted name attempts for org ${org.id}`);
+  return null;
+}
+
+module.exports = { ensureOrgChannel };

--- a/src/services/channelService.js
+++ b/src/services/channelService.js
@@ -42,4 +42,35 @@ async function ensureOrgChannel(client, org) {
   return null;
 }
 
-module.exports = { ensureOrgChannel };
+/**
+ * Invite a user to the org's daily-dose-bot channel. Best-effort: never throws.
+ * Looks up the org's botChannelId itself so callers needn't preload it.
+ * @param {object} client - Slack WebClient
+ * @param {string} orgId
+ * @param {string} slackUserId
+ * @returns {Promise<boolean>} true if invited or already a member
+ */
+async function inviteUserToOrgChannel(client, orgId, slackUserId) {
+  if (!client || !orgId || !slackUserId) return false;
+  try {
+    const org = await prisma.organization.findUnique({
+      where: { id: orgId },
+      select: { botChannelId: true },
+    });
+    if (!org?.botChannelId) return false;
+    await client.conversations.invite({
+      channel: org.botChannelId,
+      users: slackUserId,
+    });
+    return true;
+  } catch (err) {
+    if (err.data?.error === "already_in_channel") return true;
+    logger.warn(
+      `inviteUserToOrgChannel failed (org ${orgId}, user ${slackUserId}):`,
+      err.data?.error || err.message
+    );
+    return false;
+  }
+}
+
+module.exports = { ensureOrgChannel, inviteUserToOrgChannel };

--- a/src/services/teamService.js
+++ b/src/services/teamService.js
@@ -1,5 +1,6 @@
 const prisma = require("../config/prisma");
 const userService = require("./userService");
+const channelService = require("./channelService");
 const permissionHelper = require("../utils/permissionHelper");
 const { UserFacingError } = require("../utils/errorHelper");
 const { validateTimezone } = require("../utils/timeHelper");
@@ -100,6 +101,13 @@ class TeamService {
 
       return created;
     });
+
+    // Best-effort: add the creator to the org's daily-dose-bot channel.
+    await channelService.inviteUserToOrgChannel(
+      slackClient,
+      org.id,
+      slackUserId
+    );
 
     return { team, status, organization: org, creatorSlackUserId: slackUserId };
   }
@@ -265,7 +273,7 @@ class TeamService {
     }
 
     // Add as member
-    return await prisma.teamMember.upsert({
+    const member = await prisma.teamMember.upsert({
       where: {
         teamId_userId: {
           teamId: team.id,
@@ -282,6 +290,15 @@ class TeamService {
         isActive: true,
       },
     });
+
+    // Best-effort: add the member to the org's daily-dose-bot channel.
+    await channelService.inviteUserToOrgChannel(
+      slackClient,
+      team.organizationId,
+      slackUserId
+    );
+
+    return member;
   }
 
   async listTeams(slackUserId) {

--- a/test/services/channelService.test.js
+++ b/test/services/channelService.test.js
@@ -4,7 +4,10 @@ jest.mock("../../src/config/prisma", () => ({
 jest.mock("../../src/utils/logger", () => ({ warn: jest.fn() }));
 
 const prisma = require("../../src/config/prisma");
-const { ensureOrgChannel } = require("../../src/services/channelService");
+const {
+  ensureOrgChannel,
+  inviteUserToOrgChannel,
+} = require("../../src/services/channelService");
 
 function makeClient() {
   return { conversations: { create: jest.fn(), invite: jest.fn() } };
@@ -68,5 +71,51 @@ describe("ensureOrgChannel", () => {
     expect(
       await ensureOrgChannel(null, { id: "o1", botChannelId: null })
     ).toBeNull();
+  });
+});
+
+describe("inviteUserToOrgChannel", () => {
+  it("no-ops and returns false when the org has no channel", async () => {
+    prisma.organization.findUnique.mockResolvedValue({ botChannelId: null });
+    const client = makeClient();
+    const ok = await inviteUserToOrgChannel(client, "o1", "U1");
+    expect(ok).toBe(false);
+    expect(client.conversations.invite).not.toHaveBeenCalled();
+  });
+
+  it("invites the user when the org has a channel", async () => {
+    prisma.organization.findUnique.mockResolvedValue({ botChannelId: "C1" });
+    const client = makeClient();
+    client.conversations.invite.mockResolvedValue({ ok: true });
+    const ok = await inviteUserToOrgChannel(client, "o1", "U1");
+    expect(client.conversations.invite).toHaveBeenCalledWith({
+      channel: "C1",
+      users: "U1",
+    });
+    expect(ok).toBe(true);
+  });
+
+  it("treats already_in_channel as success", async () => {
+    prisma.organization.findUnique.mockResolvedValue({ botChannelId: "C1" });
+    const client = makeClient();
+    client.conversations.invite.mockRejectedValue({
+      data: { error: "already_in_channel" },
+    });
+    expect(await inviteUserToOrgChannel(client, "o1", "U1")).toBe(true);
+  });
+
+  it("returns false on other invite errors", async () => {
+    prisma.organization.findUnique.mockResolvedValue({ botChannelId: "C1" });
+    const client = makeClient();
+    client.conversations.invite.mockRejectedValue({
+      data: { error: "missing_scope" },
+    });
+    expect(await inviteUserToOrgChannel(client, "o1", "U1")).toBe(false);
+  });
+
+  it("returns false when args are missing", async () => {
+    const client = makeClient();
+    expect(await inviteUserToOrgChannel(client, "o1", null)).toBe(false);
+    expect(prisma.organization.findUnique).not.toHaveBeenCalled();
   });
 });

--- a/test/services/channelService.test.js
+++ b/test/services/channelService.test.js
@@ -55,6 +55,10 @@ describe("ensureOrgChannel", () => {
       is_private: false,
     });
     expect(id).toBe("C2");
+    expect(prisma.organization.update).toHaveBeenCalledWith({
+      where: { id: "o1" },
+      data: { botChannelId: "C2" },
+    });
   });
 
   it("returns null and does not persist on a non-name error", async () => {

--- a/test/services/channelService.test.js
+++ b/test/services/channelService.test.js
@@ -1,0 +1,72 @@
+jest.mock("../../src/config/prisma", () => ({
+  organization: { update: jest.fn(), findUnique: jest.fn() },
+}));
+jest.mock("../../src/utils/logger", () => ({ warn: jest.fn() }));
+
+const prisma = require("../../src/config/prisma");
+const { ensureOrgChannel } = require("../../src/services/channelService");
+
+function makeClient() {
+  return { conversations: { create: jest.fn(), invite: jest.fn() } };
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("ensureOrgChannel", () => {
+  it("returns the existing channel id without calling Slack", async () => {
+    const client = makeClient();
+    const id = await ensureOrgChannel(client, {
+      id: "o1",
+      botChannelId: "C_OLD",
+    });
+    expect(id).toBe("C_OLD");
+    expect(client.conversations.create).not.toHaveBeenCalled();
+  });
+
+  it("creates the channel and persists the id when none exists", async () => {
+    const client = makeClient();
+    client.conversations.create.mockResolvedValue({
+      ok: true,
+      channel: { id: "C_NEW" },
+    });
+    const id = await ensureOrgChannel(client, { id: "o1", botChannelId: null });
+    expect(client.conversations.create).toHaveBeenCalledWith({
+      name: "daily-dose-bot",
+      is_private: false,
+    });
+    expect(prisma.organization.update).toHaveBeenCalledWith({
+      where: { id: "o1" },
+      data: { botChannelId: "C_NEW" },
+    });
+    expect(id).toBe("C_NEW");
+  });
+
+  it("retries with a suffixed name on name_taken", async () => {
+    const client = makeClient();
+    client.conversations.create
+      .mockRejectedValueOnce({ data: { error: "name_taken" } })
+      .mockResolvedValueOnce({ channel: { id: "C2" } });
+    const id = await ensureOrgChannel(client, { id: "o1", botChannelId: null });
+    expect(client.conversations.create).toHaveBeenNthCalledWith(2, {
+      name: "daily-dose-bot-2",
+      is_private: false,
+    });
+    expect(id).toBe("C2");
+  });
+
+  it("returns null and does not persist on a non-name error", async () => {
+    const client = makeClient();
+    client.conversations.create.mockRejectedValue({
+      data: { error: "missing_scope" },
+    });
+    const id = await ensureOrgChannel(client, { id: "o1", botChannelId: null });
+    expect(id).toBeNull();
+    expect(prisma.organization.update).not.toHaveBeenCalled();
+  });
+
+  it("returns null when client is missing", async () => {
+    expect(
+      await ensureOrgChannel(null, { id: "o1", botChannelId: null })
+    ).toBeNull();
+  });
+});

--- a/test/services/teamServiceChannelInvite.test.js
+++ b/test/services/teamServiceChannelInvite.test.js
@@ -1,0 +1,74 @@
+jest.mock("../../src/config/prisma", () => ({
+  team: { findUnique: jest.fn(), create: jest.fn() },
+  teamMember: { findUnique: jest.fn(), upsert: jest.fn(), create: jest.fn() },
+  $transaction: jest.fn(),
+}));
+jest.mock("../../src/services/userService", () => ({
+  fetchSlackUserData: jest.fn().mockResolvedValue({}),
+  findOrCreateUser: jest.fn(),
+  getUserOrganization: jest.fn(),
+  getOrganizationByWorkspaceId: jest.fn(),
+  addUserToOrganization: jest.fn(),
+  canCreateTeam: jest.fn(),
+}));
+jest.mock("../../src/services/channelService", () => ({
+  inviteUserToOrgChannel: jest.fn().mockResolvedValue(true),
+  ensureOrgChannel: jest.fn(),
+}));
+
+const prisma = require("../../src/config/prisma");
+const userService = require("../../src/services/userService");
+const channelService = require("../../src/services/channelService");
+const teamService = require("../../src/services/teamService");
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  userService.findOrCreateUser.mockResolvedValue({ id: "u1" });
+});
+
+it("joinTeam invites the user to the org channel", async () => {
+  prisma.team.findUnique.mockResolvedValue({
+    id: "t1",
+    organizationId: "o1",
+    organization: { id: "o1" },
+  });
+  userService.getUserOrganization.mockResolvedValue({ id: "o1" });
+  prisma.teamMember.findUnique.mockResolvedValue(null);
+  prisma.teamMember.upsert.mockResolvedValue({ id: "tm1" });
+
+  const client = { conversations: {} };
+  await teamService.joinTeam("U1", "t1", client);
+
+  expect(channelService.inviteUserToOrgChannel).toHaveBeenCalledWith(
+    client,
+    "o1",
+    "U1"
+  );
+});
+
+it("createTeam invites the creator to the org channel", async () => {
+  userService.getUserOrganization.mockResolvedValue({
+    id: "o1",
+    defaultTimezone: "UTC",
+  });
+  userService.canCreateTeam.mockResolvedValue(true);
+  prisma.team.findUnique.mockResolvedValue(null); // no existing team for channel
+  prisma.$transaction.mockImplementation(async (cb) => cb(prisma));
+  prisma.team.create.mockResolvedValue({ id: "t1" });
+  prisma.teamMember.create.mockResolvedValue({});
+
+  const client = { conversations: {} };
+  await teamService.createTeam(
+    "U1",
+    "C1",
+    { name: "Eng", standupTime: "09:30", postingTime: "10:00" },
+    "W1",
+    client
+  );
+
+  expect(channelService.inviteUserToOrgChannel).toHaveBeenCalledWith(
+    client,
+    "o1",
+    "U1"
+  );
+});


### PR DESCRIPTION
Closes #50.

## What this does

- **On org creation** (admin panel): auto-creates a public Slack channel named `daily-dose-bot` for the org and stores its ID on `Organization.botChannelId`.
- **On team join** (`/dd-team-join`, team creation, and admin add-member): auto-invites the user to their org's `daily-dose-bot` channel.
- **Best-effort throughout**: every Slack call is wrapped so failures (missing scope, rate limit, outage) are logged and **never** roll back org creation or team join.
- **Forward-only**, with a manual `npm run channels:backfill` script for existing orgs/members.

## Design decisions (from the spec)

- **Channel naming**: per-org channel named `daily-dose-bot`; on a `name_taken` collision (multiple orgs in one workspace) falls back to `daily-dose-bot-2`, `-3`, … (max 5 attempts). Idempotent — an org with `botChannelId` already set short-circuits without a Slack call.
- **Backfill**: forward-only; existing orgs/members are untouched until `npm run channels:backfill` (`--dry-run` supported) is run manually.
- **Failure handling**: best-effort, log-and-continue.

## Changes

| Area | File |
| --- | --- |
| Schema + migration (`botChannelId`) | `prisma/schema.prisma`, `prisma/migrations/…_add_org_bot_channel_id/` |
| Slack channel wrapper (`ensureOrgChannel`, `inviteUserToOrgChannel`) | `src/services/channelService.js` (+10 unit tests) |
| Invite on team join | `src/services/teamService.js` (+2 tests) |
| Channel create on org-create + invite on admin add-member | `src/routes/admin.js` |
| Backfill script + npm alias | `scripts/backfillOrgChannels.js`, `package.json` |
| New bot scope `channels:manage` | `slack-app-manifest.json` |
| Docs | `CHANGELOG.md`, `README.md` |

## Testing

- `npm test` — **228/228 passing**.
- `channelService` unit tests cover: idempotent reuse, create+persist, `name_taken` retry with suffix, error paths return `null`/`false` (never throw), invite no-op when no channel, `already_in_channel` treated as success.
- Backfill `--dry-run` verified against the live dev DB (no writes).

## ⚠️ Required before this works in production

1. **Re-install / re-authorize the Slack app** to the workspace so the new `channels:manage` scope takes effect (run `npm run manifest:update`, then reinstall). Until then, channel create/invite fail with `missing_scope` — logged, non-blocking.
2. After deploy, confirm the bot can `conversations.invite` into a channel it created (it joins as creator, so it should). If invites ever fail with `not_in_channel` on a pre-existing channel, `ensureOrgChannel` would need a `conversations.join` — not added now since it's unneeded for bot-created channels.

## Review trail

Built via spec → plan → task-by-task implementation, each task spec/quality-reviewed, plus a final whole-branch review (verdict: merge with minor fixes; the one best-effort gap it found — an unguarded `prisma.user.findUnique` in the admin add-member hook — is fixed in `1ffadc4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-creates a dedicated Slack channel (`#daily-dose-bot`) per organization on setup.
  * Automatically invites members to their organization's channel when joining teams.
  * Added `npm run channels:backfill` command to provision channels and invite members for existing organizations (supports `--dry-run` option).

* **Operations**
  * Slack app manifest updated with new permissions; requires reinstallation after manifest update.

* **Documentation**
  * Updated README with org channel auto-provisioning details and guidance for operators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->