### PR TITLE
feat: auto-broadcast changelog to org channels on deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Auto-invite members to their org's `daily-dose-bot` channel on team join (`/dd-team-join`, team creation, and admin add-member). Best-effort; Slack failures are logged, never blocking.
 - `npm run channels:backfill` (supports `--dry-run`) to create channels and invite current members for existing orgs.
 - Added `channels:manage` bot scope to the Slack manifest (required for channel creation and member invites). Re-install the app to the workspace after updating the manifest.
+- Auto-broadcast the latest user-facing changelog entry to each org's `daily-dose-bot` channel on deploy (`src/services/changelogBroadcastService.js`, fired from `src/app.js` after `app.start`). Per-org `Organization.lastBroadcastVersion` marker prevents re-posting on restarts; a `null` marker is seeded silently so existing orgs aren't mass-blasted on first deploy, and new orgs are stamped with the current version at creation. Set `CHANGELOG_BROADCAST=off` to disable or `=dry` to preview without posting.
 
 ## [1.15.2] - 2026-06-21
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,7 @@ Key environment variables in `.env`:
 - **Slack tokens**: BOT_TOKEN, SIGNING_SECRET, APP_TOKEN, USER_TOKEN
 - **Database URLs**: DATABASE_URL, DIRECT_URL
 - **App settings**: PORT, DEFAULT_TIMEZONE, APP_URL
+- **Changelog broadcast**: CHANGELOG_BROADCAST (optional) — controls the on-deploy changelog announcement to each org's `daily-dose-bot` channel. `off` disables it; `dry` logs targets without posting; unset/anything else = live.
 - **Logging**: LOG_LEVEL, SENTRY_DSN (optional)
 - **Scripts Auth**: SCRIPTS_AUTH_USERNAME, SCRIPTS_AUTH_PASSWORD (for /scripts-docs route protection)
 - **Admin Panel OAuth**: ADMIN_OAUTH_REDIRECT_URI (Slack OAuth callback for the admin panel; SLACK_CLIENT_ID/SLACK_CLIENT_SECRET double as the admin OAuth credentials)

--- a/README.md
+++ b/README.md
@@ -1060,7 +1060,14 @@ PORT=3000                                 # Server port (default: 3000)
 APP_URL=https://your-domain.com           # Your application's base URL
 DEFAULT_TIMEZONE=America/New_York         # Default timezone for teams
 LOG_LEVEL=info                           # Logging level (debug, info, warn, error)
+CHANGELOG_BROADCAST=                      # Optional — on-deploy changelog announcement to each org's #daily-dose-bot channel: "off" disables, "dry" logs targets without posting, unset/anything else = live
 ```
+
+On every deploy, Daily Dose posts the latest user-facing changelog entry to each
+organization's `daily-dose-bot` channel exactly once (tracked per org via
+`Organization.lastBroadcastVersion`). Restarts never re-post, and existing orgs
+are seeded silently the first time the feature ships. Use `CHANGELOG_BROADCAST`
+above to disable or preview it.
 
 **Slack Integration:**
 

--- a/docs/superpowers/plans/2026-06-22-changelog-broadcast-on-deploy.md
+++ b/docs/superpowers/plans/2026-06-22-changelog-broadcast-on-deploy.md
@@ -1,0 +1,706 @@
+# Changelog Broadcast on Deploy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On every deploy, automatically post the latest user-facing changelog entry to each organization's `daily-dose-bot` Slack channel — exactly once per release, per org.
+
+**Architecture:** A fire-and-forget call after `app.start()` runs a new `changelogBroadcastService`. It reads the `isLatest` entry from `web/src/data/changelog.json`, compares its version against a new per-org `Organization.lastBroadcastVersion` marker, and posts only to orgs that haven't seen it. A `null` marker is seeded silently (no post) so the feature ships without mass-blasting existing orgs.
+
+**Tech Stack:** Node.js, Slack Bolt (`app.client`), Prisma/PostgreSQL, Jest.
+
+## Global Constraints
+
+- Block Kit lives only in `src/utils/blockHelper.js` — never inline blocks at call sites.
+- Process orgs **sequentially** with ~1.2 s sleep between Slack calls (Slack rate-limits ~1 req/sec/channel).
+- The broadcast must **never** block startup or crash the process — fire-and-forget with a top-level `.catch`.
+- Use `app.client` (Bolt client on `SLACK_BOT_TOKEN`), not the separate `BOT_TOKEN`.
+- Version marker source is `changelog.json`'s `isLatest` entry, NOT `package.json`.
+- This is operator-facing infra: record it in `CHANGELOG.md` only — **never** in `web/src/data/changelog.json` (that file is the broadcast payload).
+- Repo uses committed Prisma migrations — generate a migration, do not `db push`.
+
+---
+
+## File Structure
+
+- **Create** `src/services/changelogBroadcastService.js` — reads changelog, branches per org, posts, updates markers.
+- **Create** `test/services/changelogBroadcastService.test.js` — unit tests for the service.
+- **Modify** `src/utils/blockHelper.js` — add `createChangelogBroadcastBlocks` + export.
+- **Modify** `test/utils/` — add block builder test (new file `test/utils/changelogBroadcastBlocks.test.js`).
+- **Modify** `prisma/schema.prisma` — add `lastBroadcastVersion` to `Organization` + generated migration.
+- **Modify** `src/app.js` — fire-and-forget wiring after `app.start`.
+- **Modify** `src/routes/admin.js` — stamp `lastBroadcastVersion` at org creation.
+- **Modify** `CLAUDE.md`, `README.md`, `CHANGELOG.md` — docs.
+
+---
+
+## Task 1: Add `lastBroadcastVersion` column + migration
+
+**Files:**
+
+- Modify: `prisma/schema.prisma` (the `Organization` model, ~line 11-26)
+
+**Interfaces:**
+
+- Produces: `Organization.lastBroadcastVersion: string | null` (DB column `last_broadcast_version`), consumed by Tasks 3 and 5.
+
+- [ ] **Step 1: Add the field to the schema**
+
+In `prisma/schema.prisma`, inside `model Organization`, add the field next to `botChannelId`:
+
+```prisma
+  botChannelId         String?              @map("bot_channel_id")
+  lastBroadcastVersion String?              @map("last_broadcast_version")
+```
+
+- [ ] **Step 2: Generate the migration**
+
+Run: `npx prisma migrate dev --name add_org_last_broadcast_version`
+Expected: a new folder under `prisma/migrations/` containing `ALTER TABLE "organizations" ADD COLUMN "last_broadcast_version" TEXT;`, and the migration applies cleanly to the dev DB.
+
+- [ ] **Step 3: Regenerate the Prisma client**
+
+Run: `npx prisma generate`
+Expected: `✔ Generated Prisma Client`.
+
+- [ ] **Step 4: Verify the field exists on the client**
+
+Run: `node -e "const p=require('./src/config/prisma'); p.organization.findFirst({select:{lastBroadcastVersion:true}}).then(()=>{console.log('OK');process.exit(0)}).catch(e=>{console.error(e.message);process.exit(1)})"`
+Expected: prints `OK` (column is queryable).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add prisma/schema.prisma prisma/migrations
+git commit -m "feat(db): add Organization.lastBroadcastVersion for changelog broadcast"
+```
+
+---
+
+## Task 2: Block builder `createChangelogBroadcastBlocks`
+
+**Files:**
+
+- Modify: `src/utils/blockHelper.js` (add function before `module.exports` ~line 843; add name to exports)
+- Test: `test/utils/changelogBroadcastBlocks.test.js`
+
+**Interfaces:**
+
+- Consumes: existing `createSectionBlock`, `createContextBlock`, `createDividerBlock` (already in this file).
+- Produces: `createChangelogBroadcastBlocks(versionEntry, changelogUrl) -> Array<object>` where `versionEntry = { version, date, changes: [{ type, title, items: [] }] }`. Consumed by Task 3.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/utils/changelogBroadcastBlocks.test.js`:
+
+```js
+const {
+  createChangelogBroadcastBlocks,
+} = require("../../src/utils/blockHelper");
+
+const entry = {
+  version: "1.16.0",
+  date: "2026-06-22",
+  changes: [
+    { type: "added", title: "New thing", items: ["Did A", "Did B"] },
+    { type: "fixed", title: "Fixed thing", items: ["Patched C"] },
+    { type: "weird", title: "Misc", items: [] },
+  ],
+};
+
+describe("createChangelogBroadcastBlocks", () => {
+  const blocks = createChangelogBroadcastBlocks(
+    entry,
+    "https://dd.example/changelog"
+  );
+
+  it("starts with a header naming the version", () => {
+    expect(blocks[0]).toEqual({
+      type: "header",
+      text: {
+        type: "plain_text",
+        text: "🚀 What's new in Daily Dose v1.16.0",
+        emoji: true,
+      },
+    });
+  });
+
+  it("includes a section per change with the right emoji, bold title and bullets", () => {
+    const texts = blocks
+      .filter((b) => b.type === "section")
+      .map((b) => b.text.text);
+    expect(texts).toContain("✨ *New thing*\n• Did A\n• Did B");
+    expect(texts).toContain("🔧 *Fixed thing*\n• Patched C");
+    // unknown type falls back to 📌; no items => title only
+    expect(texts).toContain("📌 *Misc*");
+  });
+
+  it("ends with a context block linking to the full changelog", () => {
+    const last = blocks[blocks.length - 1];
+    expect(last.type).toBe("context");
+    expect(last.elements[0].text).toBe(
+      "<https://dd.example/changelog|View full changelog>"
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx jest test/utils/changelogBroadcastBlocks.test.js`
+Expected: FAIL — `createChangelogBroadcastBlocks is not a function`.
+
+- [ ] **Step 3: Implement the builder**
+
+In `src/utils/blockHelper.js`, add before `module.exports` (after `createNoDataBlocks`):
+
+```js
+const CHANGE_TYPE_EMOJI = {
+  added: "✨",
+  fixed: "🔧",
+  changed: "🔁",
+};
+
+/**
+ * Build the Block Kit message announcing a changelog version to an org channel.
+ * @param {{version: string, date?: string, changes?: Array<{type: string, title: string, items?: string[]}>}} versionEntry
+ * @param {string} changelogUrl - Link to the public changelog page
+ * @returns {Array<object>} Slack blocks
+ */
+function createChangelogBroadcastBlocks(versionEntry, changelogUrl) {
+  const blocks = [
+    {
+      type: "header",
+      text: {
+        type: "plain_text",
+        text: `🚀 What's new in Daily Dose v${versionEntry.version}`,
+        emoji: true,
+      },
+    },
+  ];
+
+  if (versionEntry.date) {
+    blocks.push(createContextBlock(`Released ${versionEntry.date}`));
+  }
+
+  for (const change of versionEntry.changes || []) {
+    const emoji = CHANGE_TYPE_EMOJI[change.type] || "📌";
+    const items = (change.items || []).map((item) => `• ${item}`).join("\n");
+    blocks.push(
+      createSectionBlock(
+        items
+          ? `${emoji} *${change.title}*\n${items}`
+          : `${emoji} *${change.title}*`
+      )
+    );
+  }
+
+  blocks.push(createDividerBlock());
+  blocks.push(createContextBlock(`<${changelogUrl}|View full changelog>`));
+  return blocks;
+}
+```
+
+Then add `createChangelogBroadcastBlocks,` to the `module.exports` object.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx jest test/utils/changelogBroadcastBlocks.test.js`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/blockHelper.js test/utils/changelogBroadcastBlocks.test.js
+git commit -m "feat(blocks): createChangelogBroadcastBlocks for changelog announcements"
+```
+
+---
+
+## Task 3: `changelogBroadcastService`
+
+**Files:**
+
+- Create: `src/services/changelogBroadcastService.js`
+- Test: `test/services/changelogBroadcastService.test.js`
+
+**Interfaces:**
+
+- Consumes: `createChangelogBroadcastBlocks` (Task 2); `prisma.organization.findMany/update`; `Organization.lastBroadcastVersion` (Task 1); a Slack client with `chat.postMessage`.
+- Produces:
+  - `getLatestEntry() -> object | null` — the `isLatest` changelog entry (or first, or null).
+  - `getLatestVersion() -> string | null` — `getLatestEntry()?.version`. Consumed by Task 5.
+  - `broadcastOnDeploy(client, { mode? }) -> Promise<void>`. Consumed by Task 4.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/services/changelogBroadcastService.test.js`:
+
+```js
+// Mutable mock for the changelog JSON the service reads.
+const mockChangelog = { versions: [] };
+jest.mock("../../web/src/data/changelog.json", () => mockChangelog);
+
+jest.mock("../../src/config/prisma", () => ({
+  organization: { findMany: jest.fn(), update: jest.fn() },
+}));
+jest.mock("../../src/utils/logger", () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const prisma = require("../../src/config/prisma");
+const service = require("../../src/services/changelogBroadcastService");
+
+function makeClient() {
+  return { chat: { postMessage: jest.fn().mockResolvedValue({ ok: true }) } };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Make the 1.2s inter-post sleep instant.
+  jest.spyOn(global, "setTimeout").mockImplementation((fn) => {
+    fn();
+    return 0;
+  });
+  mockChangelog.versions = [
+    {
+      version: "1.16.0",
+      date: "2026-06-22",
+      isLatest: true,
+      changes: [{ type: "added", title: "T", items: ["i"] }],
+    },
+    { version: "1.15.0", date: "2026-06-17", isLatest: false, changes: [] },
+  ];
+});
+
+afterEach(() => jest.restoreAllMocks());
+
+describe("getLatestEntry / getLatestVersion", () => {
+  it("returns the isLatest entry and its version", () => {
+    expect(service.getLatestEntry().version).toBe("1.16.0");
+    expect(service.getLatestVersion()).toBe("1.16.0");
+  });
+});
+
+describe("broadcastOnDeploy", () => {
+  it("seeds a null-marker org silently (no post, marker set)", async () => {
+    const client = makeClient();
+    prisma.organization.findMany.mockResolvedValue([
+      {
+        id: "o1",
+        name: "Org1",
+        botChannelId: "C1",
+        lastBroadcastVersion: null,
+      },
+    ]);
+    await service.broadcastOnDeploy(client, { mode: "live" });
+    expect(client.chat.postMessage).not.toHaveBeenCalled();
+    expect(prisma.organization.update).toHaveBeenCalledWith({
+      where: { id: "o1" },
+      data: { lastBroadcastVersion: "1.16.0" },
+    });
+  });
+
+  it("posts to an org on an older version, then updates its marker", async () => {
+    const client = makeClient();
+    prisma.organization.findMany.mockResolvedValue([
+      {
+        id: "o2",
+        name: "Org2",
+        botChannelId: "C2",
+        lastBroadcastVersion: "1.15.0",
+      },
+    ]);
+    await service.broadcastOnDeploy(client, { mode: "live" });
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
+    expect(client.chat.postMessage.mock.calls[0][0].channel).toBe("C2");
+    expect(prisma.organization.update).toHaveBeenCalledWith({
+      where: { id: "o2" },
+      data: { lastBroadcastVersion: "1.16.0" },
+    });
+  });
+
+  it("skips an org already on the latest version", async () => {
+    const client = makeClient();
+    prisma.organization.findMany.mockResolvedValue([
+      {
+        id: "o3",
+        name: "Org3",
+        botChannelId: "C3",
+        lastBroadcastVersion: "1.16.0",
+      },
+    ]);
+    await service.broadcastOnDeploy(client, { mode: "live" });
+    expect(client.chat.postMessage).not.toHaveBeenCalled();
+    expect(prisma.organization.update).not.toHaveBeenCalled();
+  });
+
+  it("does NOT update the marker when posting fails (retry next boot)", async () => {
+    const client = makeClient();
+    client.chat.postMessage.mockRejectedValue({
+      data: { error: "channel_not_found" },
+    });
+    prisma.organization.findMany.mockResolvedValue([
+      {
+        id: "o4",
+        name: "Org4",
+        botChannelId: "C4",
+        lastBroadcastVersion: "1.15.0",
+      },
+    ]);
+    await service.broadcastOnDeploy(client, { mode: "live" });
+    expect(prisma.organization.update).not.toHaveBeenCalled();
+  });
+
+  it("mode=dry posts nothing and updates nothing", async () => {
+    const client = makeClient();
+    prisma.organization.findMany.mockResolvedValue([
+      {
+        id: "o5",
+        name: "Org5",
+        botChannelId: "C5",
+        lastBroadcastVersion: "1.15.0",
+      },
+      {
+        id: "o6",
+        name: "Org6",
+        botChannelId: "C6",
+        lastBroadcastVersion: null,
+      },
+    ]);
+    await service.broadcastOnDeploy(client, { mode: "dry" });
+    expect(client.chat.postMessage).not.toHaveBeenCalled();
+    expect(prisma.organization.update).not.toHaveBeenCalled();
+  });
+
+  it("mode=off is a no-op (never queries orgs)", async () => {
+    const client = makeClient();
+    await service.broadcastOnDeploy(client, { mode: "off" });
+    expect(prisma.organization.findMany).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when there is no changelog entry", async () => {
+    const client = makeClient();
+    mockChangelog.versions = [];
+    await service.broadcastOnDeploy(client, { mode: "live" });
+    expect(prisma.organization.findMany).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx jest test/services/changelogBroadcastService.test.js`
+Expected: FAIL — cannot find module `../../src/services/changelogBroadcastService`.
+
+- [ ] **Step 3: Implement the service**
+
+Create `src/services/changelogBroadcastService.js`:
+
+```js
+const prisma = require("../config/prisma");
+const logger = require("../utils/logger");
+const { createChangelogBroadcastBlocks } = require("../utils/blockHelper");
+
+const SLEEP_MS = 1200; // Slack ~1 req/sec/channel — stay under the limit.
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function getWebUrl() {
+  return (process.env.APP_URL || "https://dd.jnahian.me").replace(/\/+$/, "");
+}
+
+/**
+ * Read the latest user-facing changelog entry. Best-effort: returns null
+ * (and logs) if the file is unreadable or has no entries.
+ * @returns {object|null}
+ */
+function getLatestEntry() {
+  try {
+    // eslint-disable-next-line global-require
+    const changelog = require("../../web/src/data/changelog.json");
+    const versions = (changelog && changelog.versions) || [];
+    const entry = versions.find((v) => v.isLatest) || versions[0] || null;
+    if (!entry) {
+      logger.warn("Changelog broadcast: no changelog entry found");
+      return null;
+    }
+    return entry;
+  } catch (err) {
+    logger.warn(
+      "Changelog broadcast: failed to read changelog.json:",
+      err.message
+    );
+    return null;
+  }
+}
+
+/** @returns {string|null} latest changelog version, or null */
+function getLatestVersion() {
+  const entry = getLatestEntry();
+  return entry ? entry.version : null;
+}
+
+/**
+ * Post the latest changelog entry to every active org's bot channel that
+ * hasn't seen it. Null marker = seed silently (no post). Never throws.
+ * @param {object} client - Slack WebClient (app.client)
+ * @param {{mode?: 'live'|'dry'|'off'}} [opts]
+ */
+async function broadcastOnDeploy(client, opts = {}) {
+  const mode = (
+    opts.mode ||
+    process.env.CHANGELOG_BROADCAST ||
+    "live"
+  ).toLowerCase();
+
+  if (mode === "off") {
+    logger.info("Changelog broadcast: disabled (CHANGELOG_BROADCAST=off)");
+    return;
+  }
+  if (!client) return;
+
+  const entry = getLatestEntry();
+  if (!entry) return;
+  const latest = entry.version;
+  const dryRun = mode === "dry";
+
+  const orgs = await prisma.organization.findMany({
+    where: { isActive: true, botChannelId: { not: null } },
+    select: {
+      id: true,
+      name: true,
+      botChannelId: true,
+      lastBroadcastVersion: true,
+    },
+  });
+
+  const blocks = createChangelogBroadcastBlocks(
+    entry,
+    `${getWebUrl()}/changelog`
+  );
+  const fallbackText = `What's new in Daily Dose v${latest}`;
+
+  for (const org of orgs) {
+    if (org.lastBroadcastVersion === latest) continue;
+
+    // Never-seen org: seed the marker silently, don't post.
+    if (org.lastBroadcastVersion == null) {
+      if (!dryRun) {
+        await prisma.organization.update({
+          where: { id: org.id },
+          data: { lastBroadcastVersion: latest },
+        });
+      }
+      logger.info(
+        `Changelog broadcast: seeded org "${org.name}" to v${latest} (no post)`
+      );
+      continue;
+    }
+
+    if (dryRun) {
+      logger.info(
+        `Changelog broadcast [dry]: would post v${latest} to ${org.botChannelId} (org "${org.name}")`
+      );
+      continue;
+    }
+
+    try {
+      await client.chat.postMessage({
+        channel: org.botChannelId,
+        text: fallbackText,
+        blocks,
+      });
+      await prisma.organization.update({
+        where: { id: org.id },
+        data: { lastBroadcastVersion: latest },
+      });
+      logger.info(
+        `Changelog broadcast: posted v${latest} to org "${org.name}"`
+      );
+    } catch (err) {
+      logger.warn(
+        `Changelog broadcast: failed for org "${org.name}" (${org.botChannelId}):`,
+        err.data?.error || err.message
+      );
+    }
+    await sleep(SLEEP_MS);
+  }
+}
+
+module.exports = { getLatestEntry, getLatestVersion, broadcastOnDeploy };
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx jest test/services/changelogBroadcastService.test.js`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/changelogBroadcastService.js test/services/changelogBroadcastService.test.js
+git commit -m "feat(service): changelogBroadcastService posts releases to org channels"
+```
+
+---
+
+## Task 4: Wire the broadcast into app boot
+
+**Files:**
+
+- Modify: `src/app.js` (imports near line 9; the start IIFE at lines 195-201)
+
+**Interfaces:**
+
+- Consumes: `changelogBroadcastService.broadcastOnDeploy` (Task 3), `app.client`.
+
+- [ ] **Step 1: Add imports**
+
+In `src/app.js`, after the existing `schedulerService` require (line 9), add:
+
+```js
+const changelogBroadcastService = require("./services/changelogBroadcastService");
+const logger = require("./utils/logger");
+```
+
+(If `logger` is already required in this file, skip that line.)
+
+- [ ] **Step 2: Add the fire-and-forget call after `app.start`**
+
+Change the start IIFE (lines 195-201) to:
+
+```js
+// Start app
+(async () => {
+  const port = process.env.PORT || 3000;
+  const host = process.env.HOST || "localhost";
+  await app.start(port);
+  console.log(`⚡️ Daily Dose bot is running on ${host}:${port}`);
+
+  // Fire-and-forget: announce the latest changelog to org channels.
+  // Must never block startup or crash the process.
+  changelogBroadcastService
+    .broadcastOnDeploy(app.client)
+    .catch((err) => logger.error("Changelog broadcast failed:", err.message));
+})();
+```
+
+- [ ] **Step 3: Verify the app boots and the broadcast runs in dry mode**
+
+Run: `CHANGELOG_BROADCAST=dry node src/app.js`
+Expected: the app prints its running banner, and within a few seconds the logs show either `Changelog broadcast [dry]: would post …` / `seeded …` lines or no org lines (depending on dev DB). No crash. Stop with Ctrl-C.
+
+- [ ] **Step 4: Run the full test suite**
+
+Run: `npm test`
+Expected: all tests pass (no regressions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app.js
+git commit -m "feat(app): broadcast changelog to org channels on deploy"
+```
+
+---
+
+## Task 5: Stamp `lastBroadcastVersion` at org creation
+
+**Files:**
+
+- Modify: `src/routes/admin.js` (org-creation handler, `prisma.organization.create` ~line 337)
+
+**Interfaces:**
+
+- Consumes: `changelogBroadcastService.getLatestVersion()` (Task 3).
+
+- [ ] **Step 1: Import the service**
+
+At the top of `src/routes/admin.js`, alongside the existing `channelService` require, add:
+
+```js
+const changelogBroadcastService = require("../services/changelogBroadcastService");
+```
+
+- [ ] **Step 2: Stamp the version in the create call**
+
+In the `prisma.organization.create` call (~line 337), add the field so new orgs start at the current version (and therefore receive their first _future_ release rather than being silently seeded):
+
+```js
+const org = await prisma.organization.create({
+  data: {
+    name: name.trim(),
+    slackWorkspaceId: slackWorkspaceId?.trim() || null,
+    slackWorkspaceName: slackWorkspaceName?.trim() || null,
+    defaultTimezone: defaultTimezone?.trim() || "America/New_York",
+    lastBroadcastVersion: changelogBroadcastService.getLatestVersion(),
+  },
+});
+```
+
+- [ ] **Step 3: Verify it parses and the existing admin route tests still pass**
+
+Run: `npx jest test/routes/admin.test.js`
+Expected: PASS (no regressions). If the test suite stubs org creation, it remains green; the new field is additive.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/routes/admin.js
+git commit -m "feat(admin): stamp lastBroadcastVersion when creating an org"
+```
+
+---
+
+## Task 6: Documentation
+
+**Files:**
+
+- Modify: `CHANGELOG.md` (the `## [Unreleased]` → `### Added` list, ~line 9-15)
+- Modify: `README.md` (env/config section)
+- Modify: `CLAUDE.md` (Environment Configuration section)
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Add a CHANGELOG.md entry**
+
+Under `## [Unreleased]` → `### Added`, append:
+
+```markdown
+- Auto-broadcast the latest user-facing changelog entry to each org's `daily-dose-bot` channel on deploy (`src/services/changelogBroadcastService.js`, fired from `src/app.js` after `app.start`). Per-org `Organization.lastBroadcastVersion` marker prevents re-posting on restarts; a `null` marker is seeded silently so existing orgs aren't mass-blasted on first deploy, and new orgs are stamped with the current version at creation. Set `CHANGELOG_BROADCAST=off` to disable or `=dry` to preview without posting.
+```
+
+- [ ] **Step 2: Document the env var in README.md**
+
+In the README's environment-variables/configuration section, add a line:
+
+```markdown
+- `CHANGELOG_BROADCAST` (optional) — controls the on-deploy changelog announcement to each org's `daily-dose-bot` channel. `off` disables it; `dry` logs targets without posting; unset/anything else = live.
+```
+
+(Place it near other optional app settings; match the surrounding list style.)
+
+- [ ] **Step 3: Document the env var in CLAUDE.md**
+
+In CLAUDE.md under **Environment Configuration → App settings**, add `CHANGELOG_BROADCAST` to the list of optional settings with a one-line description matching the README wording.
+
+- [ ] **Step 4: Verify markdown lints/formats**
+
+Run: `npm run format`
+Expected: no errors; files reformatted if needed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CHANGELOG.md README.md CLAUDE.md
+git commit -m "docs: document on-deploy changelog broadcast + CHANGELOG_BROADCAST env"
+```
+
+---
+
+## Final Verification
+
+- [ ] Run the full suite: `npm test` — all green.
+- [ ] `git log --oneline` shows the six task commits.
+- [ ] Manual sanity (optional, needs a dev workspace): with a real `botChannelId` org whose `lastBroadcastVersion` is an older version, run `node src/app.js` and confirm one post lands in that org's channel and the marker advances; restart and confirm no second post.

--- a/docs/superpowers/specs/2026-06-22-changelog-broadcast-on-deploy-design.md
+++ b/docs/superpowers/specs/2026-06-22-changelog-broadcast-on-deploy-design.md
@@ -1,0 +1,165 @@
+# Changelog Broadcast on Deploy — Design
+
+**Date:** 2026-06-22
+**Status:** Approved (brainstorming → ready for implementation plan)
+
+## Goal
+
+When a new release is deployed, automatically post the latest user-facing
+changelog entry to every organization's `daily-dose-bot` Slack channel — once
+per release, per org. No manual step, no spam on restarts.
+
+## How it works
+
+On boot, after `app.start(port)` succeeds in `src/app.js`, a fire-and-forget
+call into a new `changelogBroadcastService` runs the broadcast. It is wrapped so
+it can never block startup or crash the process. The service compares the latest
+user-facing changelog version against a per-org marker and posts only to orgs
+that have not yet seen that version.
+
+### Version source: `changelog.json`'s `isLatest` entry
+
+The version we compare against is the `version` of the `isLatest: true` entry in
+`web/src/data/changelog.json` — **not** `package.json`.
+
+Consequence: an internal-only release bumps `package.json` but leaves `isLatest`
+unchanged, so it automatically produces **zero broadcasts**. No "version
+mismatch" warning or `--force` logic is needed; it falls out for free.
+
+`web/src/data/changelog.json` is present on the production host: the deploy does
+a full `git checkout` / `git pull` of the repo onto the VPS (see
+`.github/workflows/deploy-version.yml`, `deploy.yml`), so the entire source tree
+is on disk even though only `web/dist/` is _served_.
+
+### Idempotency: per-org marker (mandatory)
+
+PM2 runs a single instance (`ecosystem.config.js`, `instances: 1`) with
+`autorestart: true`, so every crash/restart re-runs boot. Without a persisted
+marker this re-spams every org. Therefore:
+
+- New column **`Organization.lastBroadcastVersion String?`** (`@map("last_broadcast_version")`).
+- Boot logic: load all active orgs that have a `botChannelId`, then **branch in
+  JS** (do not rely on Prisma `{ not: latest }` null semantics — a null marker
+  must be reachable, and Prisma's `not` handling of `NULL` is version-dependent):
+  - `lastBroadcastVersion === latest` → **skip**
+  - `lastBroadcastVersion == null` → **seed silently** (set marker to `latest`,
+    do not post)
+  - otherwise → **post**, then update marker to `latest`
+- Process orgs **sequentially** with a ~1.2 s sleep between Slack calls
+  (Slack rate-limits ~1 req/sec/channel — same pattern as
+  `scripts/backfillOrgChannels.js`).
+- A failed `postMessage` logs a warning, **skips the marker update**, and is
+  retried on the next boot. Partial failures self-heal.
+
+### First-deploy safety: `null` = seed silently
+
+When the column is first added, every existing org is `null`. Treating null as
+"seed, don't post" means the feature ships **without** mass-blasting the current
+changelog to every org. Only the _next_ real release broadcasts.
+
+### New orgs: stamp at creation
+
+So that an org created _after_ launch still receives its first post-join
+release (instead of being silently seeded), set `lastBroadcastVersion` to the
+current latest version **at org-creation time** in the runtime path:
+`src/routes/admin.js` (`prisma.organization.create`, ~line 337). After this,
+`null` unambiguously means "pre-existing at feature launch."
+
+Setup scripts that upsert orgs (`scripts/seedOrg.js`, `scripts/addOrgAdmin.js`)
+are left as-is: orgs they create seed silently on next boot, which is acceptable
+for setup-time provisioning.
+
+## Components
+
+### 1. `src/utils/blockHelper.js` — block builder
+
+New `createChangelogBroadcastBlocks(versionEntry, changelogUrl)`:
+
+- `header`: `🚀 What's new in Daily Dose v{version}`
+- `context`: the release `date`
+- One `section` per `changes[]` group: emoji by `type`
+  (`added` → ✨, `fixed` → 🔧, `changed` → 🔁, fallback → 📌), **bold** `title`,
+  then bulleted `items`
+- Footer `context` with `<{webUrl}/changelog|View full changelog>`
+
+Follows `docs/slack-markdown-guidelines.md`. No blocks are inlined at call sites.
+
+### 2. `src/services/changelogBroadcastService.js` — orchestration
+
+- `getLatestEntry()` — read `web/src/data/changelog.json`, return the
+  `isLatest: true` entry (or the first entry as fallback). Returns `null` and
+  logs a warning if no entry is found (defensive no-op).
+- `broadcastOnDeploy(client, { mode })` — the boot query, JS branch, sequential
+  loop, sleep, marker updates, null-seeding. `mode` derived from
+  `CHANGELOG_BROADCAST` env: `off` (skip entirely), `dry` (log targets + a
+  rendered preview, send nothing, **do not** update markers), default = live.
+- `getLatestVersion()` — convenience for the org-creation stamp.
+
+Keeping this in a service (not `app.js`) keeps `app.js` thin and makes the
+logic unit-testable.
+
+### 3. `src/app.js` — wiring
+
+After `await app.start(port)`, one fire-and-forget call:
+
+```js
+changelogBroadcastService
+  .broadcastOnDeploy(app.client)
+  .catch((err) => logger.error("Changelog broadcast failed:", err.message));
+```
+
+Use `app.client` (Bolt's client, on `SLACK_BOT_TOKEN`) — not the separate
+`BOT_TOKEN` used by scripts/admin — to avoid token ambiguity.
+
+### 4. `prisma/schema.prisma` + migration
+
+Add `lastBroadcastVersion String? @map("last_broadcast_version")` to
+`Organization`. Generate a **committed migration**
+(`prisma migrate dev --name add_org_last_broadcast_version`), consistent with
+the repo's migration policy. Run `npx prisma generate`.
+
+### 5. `src/routes/admin.js` — org-creation stamp
+
+In the `prisma.organization.create` call, add
+`lastBroadcastVersion: changelogBroadcastService.getLatestVersion()`.
+
+### 6. Docs
+
+- `CLAUDE.md` / `README.md`: note the auto-broadcast behavior and the
+  `CHANGELOG_BROADCAST` env (`off` / `dry`).
+- `CHANGELOG.md`: technical entry. **Not** `web/src/data/changelog.json` — this
+  feature is operator-facing infra, not a user-visible bot feature, so adding it
+  there would (ironically) broadcast itself.
+
+## Error handling
+
+Best-effort throughout, mirroring `backfillOrgChannels.js`:
+
+- Top-level `.catch` on the fire-and-forget call logs via `logger.error` — never
+  silently swallowed.
+- Per-org `postMessage` failure (archived channel, bot removed, rate limit):
+  `logger.warn`, skip marker update, continue the loop, retry next boot.
+- Missing/empty `isLatest` entry: log a warning, no-op.
+
+## Testing (Jest)
+
+Service-level unit tests with a mocked Slack client and Prisma:
+
+- `lastBroadcastVersion == null` → **no post**, marker set to latest
+- `lastBroadcastVersion` differs from latest → **posts**, marker updated
+- `lastBroadcastVersion === latest` → **skipped**, no post
+- `postMessage` throws → marker **not** updated (retried next boot)
+- `mode = dry` → no posts, **no** marker updates
+- `mode = off` → service is a no-op
+- no `isLatest` entry → no-op + warning
+- Block builder: renders header/version, per-type emoji, bullets, changelog link
+
+## Out of scope (YAGNI)
+
+- GitHub Actions / release-skill trigger (auto-on-deploy replaces it)
+- Per-org opt-out UI
+- `@channel` mention (posts land quietly in-channel)
+- Manual CLI re-broadcast script (can be added later if a forced re-send is ever
+  needed)
+- Multi-instance dedup (single PM2 instance; revisit only if cluster mode is
+  adopted)

--- a/prisma/migrations/20260622080514_add_org_last_broadcast_version/migration.sql
+++ b/prisma/migrations/20260622080514_add_org_last_broadcast_version/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."organizations" ADD COLUMN     "last_broadcast_version" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,6 +15,7 @@ model Organization {
   slackWorkspaceName String?              @map("slack_workspace_name")
   defaultTimezone    String               @default("America/New_York") @map("default_timezone")
   botChannelId       String?              @map("bot_channel_id")
+  lastBroadcastVersion String?            @map("last_broadcast_version")
   settings           Json                 @default("{}")
   isActive           Boolean              @default(true) @map("is_active")
   createdAt          DateTime             @default(now()) @map("created_at")

--- a/src/app.js
+++ b/src/app.js
@@ -7,6 +7,7 @@ const { setupCommands } = require("./commands");
 const { setupWorkflows } = require("./workflows");
 const { setupEvents } = require("./events");
 const schedulerService = require("./services/schedulerService");
+const changelogBroadcastService = require("./services/changelogBroadcastService");
 
 const receiver = new ExpressReceiver({
   signingSecret: process.env.SLACK_SIGNING_SECRET,
@@ -198,6 +199,12 @@ app.message("hello", async ({ message, say }) => {
   const host = process.env.HOST || "localhost";
   await app.start(port);
   console.log(`⚡️ Daily Dose bot is running on ${host}:${port}`);
+
+  // Fire-and-forget: announce the latest changelog to org channels.
+  // Must never block startup or crash the process.
+  changelogBroadcastService
+    .broadcastOnDeploy(app.client)
+    .catch((err) => logger.error("Changelog broadcast failed:", err.message));
 })();
 
 // Graceful shutdown

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -8,6 +8,7 @@ const crypto = require("crypto");
 const schedulerService = require("../services/schedulerService");
 const mcpTokenService = require("../services/mcpTokenService");
 const channelService = require("../services/channelService");
+const changelogBroadcastService = require("../services/changelogBroadcastService");
 const oauthTokenService = require("../mcp/auth/oauthTokenService");
 
 // In-memory OAuth state store (state → expiry timestamp)
@@ -340,6 +341,7 @@ router.post(
           slackWorkspaceId: slackWorkspaceId?.trim() || null,
           slackWorkspaceName: slackWorkspaceName?.trim() || null,
           defaultTimezone: defaultTimezone?.trim() || "America/New_York",
+          lastBroadcastVersion: changelogBroadcastService.getLatestVersion(),
         },
       });
       // Best-effort: create the org's daily-dose-bot Slack channel.

--- a/src/services/changelogBroadcastService.js
+++ b/src/services/changelogBroadcastService.js
@@ -109,6 +109,17 @@ async function broadcastOnDeploy(client, opts = {}) {
         text: fallbackText,
         blocks,
       });
+    } catch (err) {
+      // Post failed: leave the marker untouched so this org retries next boot.
+      logger.warn(
+        `Changelog broadcast: failed for org "${org.name}" (${org.botChannelId}):`,
+        err.data?.error || err.message
+      );
+      await sleep(SLEEP_MS);
+      continue;
+    }
+
+    try {
       await prisma.organization.update({
         where: { id: org.id },
         data: { lastBroadcastVersion: latest },
@@ -117,9 +128,11 @@ async function broadcastOnDeploy(client, opts = {}) {
         `Changelog broadcast: posted v${latest} to org "${org.name}"`
       );
     } catch (err) {
+      // Post succeeded but the marker write failed; this org will re-post on
+      // the next boot (intentional "never miss" over "never duplicate").
       logger.warn(
-        `Changelog broadcast: failed for org "${org.name}" (${org.botChannelId}):`,
-        err.data?.error || err.message
+        `Changelog broadcast: posted v${latest} to org "${org.name}" but failed to persist marker; may re-post next boot:`,
+        err.message
       );
     }
     await sleep(SLEEP_MS);

--- a/src/services/changelogBroadcastService.js
+++ b/src/services/changelogBroadcastService.js
@@ -91,7 +91,7 @@ async function broadcastOnDeploy(client, opts = {}) {
         });
       }
       logger.info(
-        `Changelog broadcast: seeded org "${org.name}" to v${latest} (no post)`
+        `Changelog broadcast: ${dryRun ? "would seed" : "seeded"} org "${org.name}" to v${latest} (no post)`
       );
       continue;
     }

--- a/src/services/changelogBroadcastService.js
+++ b/src/services/changelogBroadcastService.js
@@ -1,0 +1,129 @@
+const prisma = require("../config/prisma");
+const logger = require("../utils/logger");
+const { createChangelogBroadcastBlocks } = require("../utils/blockHelper");
+
+const SLEEP_MS = 1200; // Slack ~1 req/sec/channel — stay under the limit.
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function getWebUrl() {
+  return (process.env.APP_URL || "https://dd.jnahian.me").replace(/\/+$/, "");
+}
+
+/**
+ * Read the latest user-facing changelog entry. Best-effort: returns null
+ * (and logs) if the file is unreadable or has no entries.
+ * @returns {object|null}
+ */
+function getLatestEntry() {
+  try {
+    const changelog = require("../../web/src/data/changelog.json");
+    const versions = (changelog && changelog.versions) || [];
+    const entry = versions.find((v) => v.isLatest) || versions[0] || null;
+    if (!entry) {
+      logger.warn("Changelog broadcast: no changelog entry found");
+      return null;
+    }
+    return entry;
+  } catch (err) {
+    logger.warn(
+      "Changelog broadcast: failed to read changelog.json:",
+      err.message
+    );
+    return null;
+  }
+}
+
+/** @returns {string|null} latest changelog version, or null */
+function getLatestVersion() {
+  const entry = getLatestEntry();
+  return entry ? entry.version : null;
+}
+
+/**
+ * Post the latest changelog entry to every active org's bot channel that
+ * hasn't seen it. Null marker = seed silently (no post). Never throws.
+ * @param {object} client - Slack WebClient (app.client)
+ * @param {{mode?: 'live'|'dry'|'off'}} [opts]
+ */
+async function broadcastOnDeploy(client, opts = {}) {
+  const mode = (
+    opts.mode ||
+    process.env.CHANGELOG_BROADCAST ||
+    "live"
+  ).toLowerCase();
+
+  if (mode === "off") {
+    logger.info("Changelog broadcast: disabled (CHANGELOG_BROADCAST=off)");
+    return;
+  }
+  if (!client) return;
+
+  const entry = getLatestEntry();
+  if (!entry) return;
+  const latest = entry.version;
+  const dryRun = mode === "dry";
+
+  const orgs = await prisma.organization.findMany({
+    where: { isActive: true, botChannelId: { not: null } },
+    select: {
+      id: true,
+      name: true,
+      botChannelId: true,
+      lastBroadcastVersion: true,
+    },
+  });
+
+  const blocks = createChangelogBroadcastBlocks(
+    entry,
+    `${getWebUrl()}/changelog`
+  );
+  const fallbackText = `What's new in Daily Dose v${latest}`;
+
+  for (const org of orgs) {
+    if (org.lastBroadcastVersion === latest) continue;
+
+    // Never-seen org: seed the marker silently, don't post.
+    if (org.lastBroadcastVersion === null) {
+      if (!dryRun) {
+        await prisma.organization.update({
+          where: { id: org.id },
+          data: { lastBroadcastVersion: latest },
+        });
+      }
+      logger.info(
+        `Changelog broadcast: seeded org "${org.name}" to v${latest} (no post)`
+      );
+      continue;
+    }
+
+    if (dryRun) {
+      logger.info(
+        `Changelog broadcast [dry]: would post v${latest} to ${org.botChannelId} (org "${org.name}")`
+      );
+      continue;
+    }
+
+    try {
+      await client.chat.postMessage({
+        channel: org.botChannelId,
+        text: fallbackText,
+        blocks,
+      });
+      await prisma.organization.update({
+        where: { id: org.id },
+        data: { lastBroadcastVersion: latest },
+      });
+      logger.info(
+        `Changelog broadcast: posted v${latest} to org "${org.name}"`
+      );
+    } catch (err) {
+      logger.warn(
+        `Changelog broadcast: failed for org "${org.name}" (${org.botChannelId}):`,
+        err.data?.error || err.message
+      );
+    }
+    await sleep(SLEEP_MS);
+  }
+}
+
+module.exports = { getLatestEntry, getLatestVersion, broadcastOnDeploy };

--- a/src/utils/blockHelper.js
+++ b/src/utils/blockHelper.js
@@ -840,8 +840,54 @@ function createNoDataBlocks(context = "data", date = null) {
   ];
 }
 
+const CHANGE_TYPE_EMOJI = {
+  added: "✨",
+  fixed: "🔧",
+  changed: "🔁",
+};
+
+/**
+ * Build the Block Kit message announcing a changelog version to an org channel.
+ * @param {{version: string, date?: string, changes?: Array<{type: string, title: string, items?: string[]}>}} versionEntry
+ * @param {string} changelogUrl - Link to the public changelog page
+ * @returns {Array<object>} Slack blocks
+ */
+function createChangelogBroadcastBlocks(versionEntry, changelogUrl) {
+  const blocks = [
+    {
+      type: "header",
+      text: {
+        type: "plain_text",
+        text: `🚀 What's new in Daily Dose v${versionEntry.version}`,
+        emoji: true,
+      },
+    },
+  ];
+
+  if (versionEntry.date) {
+    blocks.push(createContextBlock(`Released ${versionEntry.date}`));
+  }
+
+  for (const change of versionEntry.changes || []) {
+    const emoji = CHANGE_TYPE_EMOJI[change.type] || "📌";
+    const items = (change.items || []).map((item) => `• ${item}`).join("\n");
+    blocks.push(
+      createSectionBlock(
+        items
+          ? `${emoji} *${change.title}*\n${items}`
+          : `${emoji} *${change.title}*`
+      )
+    );
+  }
+
+  blocks.push(createDividerBlock());
+  blocks.push(createContextBlock(`<${changelogUrl}|View full changelog>`));
+  return blocks;
+}
+
 module.exports = {
   createSectionBlock,
+  createChangelogBroadcastBlocks,
   createFieldsBlock,
   createTaskFieldBlocks,
   createContextBlock,

--- a/test/services/changelogBroadcastService.test.js
+++ b/test/services/changelogBroadcastService.test.js
@@ -76,7 +76,11 @@ describe("broadcastOnDeploy", () => {
     ]);
     await service.broadcastOnDeploy(client, { mode: "live" });
     expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
-    expect(client.chat.postMessage.mock.calls[0][0].channel).toBe("C2");
+    expect(client.chat.postMessage.mock.calls[0][0]).toMatchObject({
+      channel: "C2",
+      text: "What's new in Daily Dose v1.16.0",
+      blocks: expect.any(Array),
+    });
     expect(prisma.organization.update).toHaveBeenCalledWith({
       where: { id: "o2" },
       data: { lastBroadcastVersion: "1.16.0" },

--- a/test/services/changelogBroadcastService.test.js
+++ b/test/services/changelogBroadcastService.test.js
@@ -119,6 +119,24 @@ describe("broadcastOnDeploy", () => {
     expect(prisma.organization.update).not.toHaveBeenCalled();
   });
 
+  it("does not throw when the post succeeds but the marker write fails", async () => {
+    const client = makeClient();
+    prisma.organization.findMany.mockResolvedValue([
+      {
+        id: "o7",
+        name: "Org7",
+        botChannelId: "C7",
+        lastBroadcastVersion: "1.15.0",
+      },
+    ]);
+    prisma.organization.update.mockRejectedValue(new Error("db blip"));
+    await expect(
+      service.broadcastOnDeploy(client, { mode: "live" })
+    ).resolves.toBeUndefined();
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
+    expect(prisma.organization.update).toHaveBeenCalledTimes(1);
+  });
+
   it("mode=dry posts nothing and updates nothing", async () => {
     const client = makeClient();
     prisma.organization.findMany.mockResolvedValue([

--- a/test/services/changelogBroadcastService.test.js
+++ b/test/services/changelogBroadcastService.test.js
@@ -1,0 +1,151 @@
+// Mutable mock for the changelog JSON the service reads.
+const mockChangelog = { versions: [] };
+jest.mock("../../web/src/data/changelog.json", () => mockChangelog);
+
+jest.mock("../../src/config/prisma", () => ({
+  organization: { findMany: jest.fn(), update: jest.fn() },
+}));
+jest.mock("../../src/utils/logger", () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const prisma = require("../../src/config/prisma");
+const service = require("../../src/services/changelogBroadcastService");
+
+function makeClient() {
+  return { chat: { postMessage: jest.fn().mockResolvedValue({ ok: true }) } };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Make the 1.2s inter-post sleep instant.
+  jest.spyOn(global, "setTimeout").mockImplementation((fn) => {
+    fn();
+    return 0;
+  });
+  mockChangelog.versions = [
+    {
+      version: "1.16.0",
+      date: "2026-06-22",
+      isLatest: true,
+      changes: [{ type: "added", title: "T", items: ["i"] }],
+    },
+    { version: "1.15.0", date: "2026-06-17", isLatest: false, changes: [] },
+  ];
+});
+
+afterEach(() => jest.restoreAllMocks());
+
+describe("getLatestEntry / getLatestVersion", () => {
+  it("returns the isLatest entry and its version", () => {
+    expect(service.getLatestEntry().version).toBe("1.16.0");
+    expect(service.getLatestVersion()).toBe("1.16.0");
+  });
+});
+
+describe("broadcastOnDeploy", () => {
+  it("seeds a null-marker org silently (no post, marker set)", async () => {
+    const client = makeClient();
+    prisma.organization.findMany.mockResolvedValue([
+      {
+        id: "o1",
+        name: "Org1",
+        botChannelId: "C1",
+        lastBroadcastVersion: null,
+      },
+    ]);
+    await service.broadcastOnDeploy(client, { mode: "live" });
+    expect(client.chat.postMessage).not.toHaveBeenCalled();
+    expect(prisma.organization.update).toHaveBeenCalledWith({
+      where: { id: "o1" },
+      data: { lastBroadcastVersion: "1.16.0" },
+    });
+  });
+
+  it("posts to an org on an older version, then updates its marker", async () => {
+    const client = makeClient();
+    prisma.organization.findMany.mockResolvedValue([
+      {
+        id: "o2",
+        name: "Org2",
+        botChannelId: "C2",
+        lastBroadcastVersion: "1.15.0",
+      },
+    ]);
+    await service.broadcastOnDeploy(client, { mode: "live" });
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
+    expect(client.chat.postMessage.mock.calls[0][0].channel).toBe("C2");
+    expect(prisma.organization.update).toHaveBeenCalledWith({
+      where: { id: "o2" },
+      data: { lastBroadcastVersion: "1.16.0" },
+    });
+  });
+
+  it("skips an org already on the latest version", async () => {
+    const client = makeClient();
+    prisma.organization.findMany.mockResolvedValue([
+      {
+        id: "o3",
+        name: "Org3",
+        botChannelId: "C3",
+        lastBroadcastVersion: "1.16.0",
+      },
+    ]);
+    await service.broadcastOnDeploy(client, { mode: "live" });
+    expect(client.chat.postMessage).not.toHaveBeenCalled();
+    expect(prisma.organization.update).not.toHaveBeenCalled();
+  });
+
+  it("does NOT update the marker when posting fails (retry next boot)", async () => {
+    const client = makeClient();
+    client.chat.postMessage.mockRejectedValue({
+      data: { error: "channel_not_found" },
+    });
+    prisma.organization.findMany.mockResolvedValue([
+      {
+        id: "o4",
+        name: "Org4",
+        botChannelId: "C4",
+        lastBroadcastVersion: "1.15.0",
+      },
+    ]);
+    await service.broadcastOnDeploy(client, { mode: "live" });
+    expect(prisma.organization.update).not.toHaveBeenCalled();
+  });
+
+  it("mode=dry posts nothing and updates nothing", async () => {
+    const client = makeClient();
+    prisma.organization.findMany.mockResolvedValue([
+      {
+        id: "o5",
+        name: "Org5",
+        botChannelId: "C5",
+        lastBroadcastVersion: "1.15.0",
+      },
+      {
+        id: "o6",
+        name: "Org6",
+        botChannelId: "C6",
+        lastBroadcastVersion: null,
+      },
+    ]);
+    await service.broadcastOnDeploy(client, { mode: "dry" });
+    expect(client.chat.postMessage).not.toHaveBeenCalled();
+    expect(prisma.organization.update).not.toHaveBeenCalled();
+  });
+
+  it("mode=off is a no-op (never queries orgs)", async () => {
+    const client = makeClient();
+    await service.broadcastOnDeploy(client, { mode: "off" });
+    expect(prisma.organization.findMany).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when there is no changelog entry", async () => {
+    const client = makeClient();
+    mockChangelog.versions = [];
+    await service.broadcastOnDeploy(client, { mode: "live" });
+    expect(prisma.organization.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/test/utils/changelogBroadcastBlocks.test.js
+++ b/test/utils/changelogBroadcastBlocks.test.js
@@ -1,0 +1,49 @@
+const {
+  createChangelogBroadcastBlocks,
+} = require("../../src/utils/blockHelper");
+
+const entry = {
+  version: "1.16.0",
+  date: "2026-06-22",
+  changes: [
+    { type: "added", title: "New thing", items: ["Did A", "Did B"] },
+    { type: "fixed", title: "Fixed thing", items: ["Patched C"] },
+    { type: "weird", title: "Misc", items: [] },
+  ],
+};
+
+describe("createChangelogBroadcastBlocks", () => {
+  const blocks = createChangelogBroadcastBlocks(
+    entry,
+    "https://dd.example/changelog"
+  );
+
+  it("starts with a header naming the version", () => {
+    expect(blocks[0]).toEqual({
+      type: "header",
+      text: {
+        type: "plain_text",
+        text: "🚀 What's new in Daily Dose v1.16.0",
+        emoji: true,
+      },
+    });
+  });
+
+  it("includes a section per change with the right emoji, bold title and bullets", () => {
+    const texts = blocks
+      .filter((b) => b.type === "section")
+      .map((b) => b.text.text);
+    expect(texts).toContain("✨ *New thing*\n• Did A\n• Did B");
+    expect(texts).toContain("🔧 *Fixed thing*\n• Patched C");
+    // unknown type falls back to 📌; no items => title only
+    expect(texts).toContain("📌 *Misc*");
+  });
+
+  it("ends with a context block linking to the full changelog", () => {
+    const last = blocks[blocks.length - 1];
+    expect(last.type).toBe("context");
+    expect(last.elements[0].text).toBe(
+      "<https://dd.example/changelog|View full changelog>"
+    );
+  });
+});


### PR DESCRIPTION
Closes #52.

## What

On every deploy, post the latest user-facing changelog entry to each org's `daily-dose-bot` Slack channel — exactly once per release, per org. Fire-and-forget after `app.start()`; never blocks or crashes boot.

## How

- **Version marker = `changelog.json`'s `isLatest` entry** (not `package.json`), so internal-only releases broadcast nothing for free.
- **Per-org `Organization.lastBroadcastVersion`** (new column + committed migration). Boot loads all active orgs with a `botChannelId` and branches in JS (avoids Prisma `not`/NULL ambiguity):
  - `=== latest` → skip
  - `null` → **seed silently** (set marker, no post)
  - else → post, then update marker
- **Sequential** posting with ~1.2 s sleep (Slack ~1 req/sec/channel). A failed post logs a warning, skips the marker update, and retries next boot (self-healing).
- **First deploy:** existing orgs are `null` → seeded silently, no mass-blast. **New orgs** stamped with the current version at creation (`admin.js`) so they still get their first post-join release.
- **Escape hatch:** `CHANGELOG_BROADCAST=off` (disable) / `dry` (log targets, no post).

## Commits

1. `feat(db)` — `Organization.lastBroadcastVersion` column + migration
2. `feat(blocks)` — `createChangelogBroadcastBlocks` in `blockHelper.js`
3. `feat(service)` — `changelogBroadcastService` (+ 8 unit tests)
4. `feat(app)` — fire-and-forget wiring after `app.start`
5. `feat(admin)` — stamp version at org creation
6. `docs` — CHANGELOG.md / README.md / CLAUDE.md
(plus the design spec and implementation plan under `docs/superpowers/`)

## Testing

- 239 tests pass (block builder + all 7 service branches: null-seed, post+update, skip-latest, post-failure-no-update, dry, off, missing-entry).
- Live boot in `CHANGELOG_BROADCAST=dry` confirmed the loop reaches orgs and takes the seed-silent path with the correct version.

## ⚠️ Reviewer notes — not yet verified / decisions to confirm

1. **Live post path unverified.** Every post-path test is mocked; the live smoke test only exercised the seed-silent branch. No message has been posted to a real channel yet.
2. **Token identity (please confirm in prod).** Org channels are *created* by the `BOT_TOKEN` bot (`admin.js`, backfill); this broadcast *posts* via `app.client` = `SLACK_BOT_TOKEN`. It's one Slack app so these are almost certainly the same token, but if prod's two vars resolve to different bots, posts fail `not_in_channel` silently. Confirm `BOT_TOKEN == SLACK_BOT_TOKEN` in prod `.env`.
3. **Duplicate-on-DB-blip tradeoff.** Post happens before the marker update; a DB failure after a successful post re-posts that org next boot. Chose "never miss" over "never duplicate" — flagging intentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated “latest changelog” announcements are posted to each organization’s Slack `daily-dose-bot` channel on deploy.
  * Duplicate notifications are prevented via a per-organization idempotency marker, with safe first-deploy seeding.
  * Added `CHANGELOG_BROADCAST` controls (`off`, `dry`, live) for disabling or previewing behavior.
* **Documentation**
  * Updated README/CHANGELOG/CLAUDE with the new environment variable and expected deploy behavior.
* **Tests**
  * Added Jest coverage for changelog broadcast logic and Slack block formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->