### PR TITLE
feat: show member status in /dd-team-list & /dd-team-members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `npm run channels:backfill` (supports `--dry-run`) to create channels and invite current members for existing orgs.
 - Added `channels:manage` bot scope to the Slack manifest (required for channel creation and member invites). Re-install the app to the workspace after updating the manifest.
 - Auto-broadcast the latest user-facing changelog entry to each org's `daily-dose-bot` channel on deploy (`src/services/changelogBroadcastService.js`, fired from `src/app.js` after `app.start`). Per-org `Organization.lastBroadcastVersion` marker prevents re-posting on restarts; a `null` marker is seeded silently so existing orgs aren't mass-blasted on first deploy, and new orgs are stamped with the current version at creation. Set `CHANGELOG_BROADCAST=off` to disable or `=dry` to preview without posting.
+- Member status in `/dd-team-list` (compact, nested per team) and `/dd-team-members` (detailed cards): today's standup, on-leave, notifications on/off, role, and active/inactive (team & org). Standup status is suppressed for admins and on non-work-days/holidays. New `deriveMemberStatus` resolver, `teamService.getTeamMembersWithStatus`, and `blockHelper` renderers.
 
 ## [1.15.2] - 2026-06-21
 

--- a/README.md
+++ b/README.md
@@ -386,6 +386,8 @@ These commands allow team admins and organization owners to manually trigger sta
   - 🔔 Reminder time (when standup reminders are sent)
   - 📊 Posting time (when standup summaries are posted)
   - 🌍 Timezone for each team
+  - Lists members compactly under each team with their current status: today's standup (submitted/not), on leave, notifications on/off, role (admin/member), and active/inactive (team & org)
+  - Standup status is hidden for admins and on non-work-days/holidays
 - `/dd-team-join [team-name]` - Join a team
   - **Channel-based**: `/dd-team-join` (joins the team in current channel)
   - **Name-based**: `/dd-team-join Engineering` (joins specific team by name from any channel)
@@ -395,6 +397,8 @@ These commands allow team admins and organization owners to manually trigger sta
 - `/dd-team-members [team-name]` - View team members
   - **Channel-based**: `/dd-team-members` (shows members of team in current channel)
   - **Name-based**: `/dd-team-members Engineering` (shows members of specific team from any channel)
+  - Shows a detailed card per member with their current status: today's standup (submitted/not), on leave, notifications on/off, role (admin/member), and active/inactive (team & org)
+  - Standup status is hidden for admins and on non-work-days/holidays
 - `/dd-team-create [team-name] <standup-time> <posting-time>` - Create a new team
   - **Channel-based**: `/dd-team-create 09:30 10:00` (uses channel name as team name)
   - **Custom name**: `/dd-team-create Engineering 09:30 10:00` (creates team with custom name)

--- a/docs/superpowers/plans/2026-06-23-member-status-in-team-commands.md
+++ b/docs/superpowers/plans/2026-06-23-member-status-in-team-commands.md
@@ -1,0 +1,792 @@
+# Member Status in Team Commands Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show each team member's current status (today's standup, on-leave, notifications, role, active/inactive) in `/dd-team-members` (detailed cards) and `/dd-team-list` (compact, nested under each team).
+
+**Architecture:** A pure resolver (`deriveMemberStatus`) encodes the status precedence and is unit-tested in isolation. A new `teamService.getTeamMembersWithStatus` assembles the raw per-member facts from the DB (reusing `getHolidayDateSet` / `isWorkingDayPure` for work-day gating). Two new `blockHelper` functions render the two layouts. The two command handlers in `team.js` wire them together.
+
+**Tech Stack:** Node.js, Slack Bolt, Prisma (PostgreSQL), dayjs, Jest.
+
+## Global Constraints
+
+- **All Block Kit lives in `src/utils/blockHelper.js`** — never inline blocks at call sites.
+- **No parallel Slack/DB fan-out across teams** — process teams sequentially.
+- **Prisma client** is imported from `src/config/prisma`.
+- **Dates:** use dayjs with the team's timezone; "today" = `dayjs().tz(team.timezone).startOf("day")`.
+- **Match existing query patterns** — do not add `deletedAt` filtering (existing leave/response queries omit it).
+- **Two changelogs:** `CHANGELOG.md` always; `web/src/data/changelog.json` only for the user-facing summary. No Slack manifest change (no new command).
+- **Status precedence (first match wins):** inactive (team OR org) → on-leave → admin (suppress standup) → non-work-day (suppress standup) → submitted → not-submitted.
+
+---
+
+### Task 1: Pure status resolver `deriveMemberStatus`
+
+**Files:**
+- Create: `src/utils/memberStatusHelper.js`
+- Test: `test/utils/memberStatusHelper.test.js`
+
+**Interfaces:**
+- Produces: `deriveMemberStatus(member) → { active: boolean, inactiveScope: 'team'|'org'|null, standup: 'leave'|'submitted'|'pending'|null }`
+  - Input `member`: `{ role, teamActive, orgActive, onLeave, workingToday, responded }`
+  - `active` = `teamActive && orgActive`.
+  - `inactiveScope` = `null` when active; else `'team'` if `!teamActive`, otherwise `'org'`.
+  - `standup` = `null` when inactive, admin, or non-work-day; `'leave'` when on leave; else `'submitted'`/`'pending'` by `responded`. On-leave outranks admin/work-day.
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// test/utils/memberStatusHelper.test.js
+const { deriveMemberStatus } = require("../../src/utils/memberStatusHelper");
+
+const base = {
+  role: "MEMBER",
+  teamActive: true,
+  orgActive: true,
+  onLeave: false,
+  workingToday: true,
+  responded: false,
+};
+
+describe("deriveMemberStatus", () => {
+  it("flags team-inactive members and suppresses standup", () => {
+    expect(deriveMemberStatus({ ...base, teamActive: false })).toEqual({
+      active: false,
+      inactiveScope: "team",
+      standup: null,
+    });
+  });
+
+  it("flags org-inactive members (team active) as org scope", () => {
+    expect(deriveMemberStatus({ ...base, orgActive: false })).toEqual({
+      active: false,
+      inactiveScope: "org",
+      standup: null,
+    });
+  });
+
+  it("prefers team scope when inactive in both", () => {
+    expect(
+      deriveMemberStatus({ ...base, teamActive: false, orgActive: false })
+        .inactiveScope
+    ).toBe("team");
+  });
+
+  it("shows on-leave even for admins", () => {
+    expect(
+      deriveMemberStatus({ ...base, role: "ADMIN", onLeave: true }).standup
+    ).toBe("leave");
+  });
+
+  it("suppresses standup for active admins", () => {
+    expect(deriveMemberStatus({ ...base, role: "ADMIN" }).standup).toBeNull();
+  });
+
+  it("suppresses standup on a non-work-day", () => {
+    expect(deriveMemberStatus({ ...base, workingToday: false }).standup).toBeNull();
+  });
+
+  it("reports submitted when responded on a work day", () => {
+    expect(deriveMemberStatus({ ...base, responded: true }).standup).toBe(
+      "submitted"
+    );
+  });
+
+  it("reports pending when not responded on a work day", () => {
+    expect(deriveMemberStatus(base).standup).toBe("pending");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest test/utils/memberStatusHelper.test.js`
+Expected: FAIL — `Cannot find module '../../src/utils/memberStatusHelper'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```js
+// src/utils/memberStatusHelper.js
+/**
+ * Pure resolver for a team member's display status.
+ * @param {Object} member
+ * @param {('ADMIN'|'MEMBER')} member.role
+ * @param {boolean} member.teamActive  TeamMember.isActive
+ * @param {boolean} member.orgActive   OrganizationMember.isActive
+ * @param {boolean} member.onLeave     leave overlaps today
+ * @param {boolean} member.workingToday today is a work day (and not a holiday)
+ * @param {boolean} member.responded   submitted a standup today
+ * @returns {{active: boolean, inactiveScope: ('team'|'org'|null), standup: ('leave'|'submitted'|'pending'|null)}}
+ */
+function deriveMemberStatus({
+  role,
+  teamActive,
+  orgActive,
+  onLeave,
+  workingToday,
+  responded,
+}) {
+  const active = teamActive && orgActive;
+  if (!active) {
+    return {
+      active: false,
+      inactiveScope: !teamActive ? "team" : "org",
+      standup: null,
+    };
+  }
+
+  let standup;
+  if (onLeave) {
+    standup = "leave";
+  } else if (role === "ADMIN" || !workingToday) {
+    standup = null;
+  } else {
+    standup = responded ? "submitted" : "pending";
+  }
+
+  return { active: true, inactiveScope: null, standup };
+}
+
+module.exports = { deriveMemberStatus };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest test/utils/memberStatusHelper.test.js`
+Expected: PASS (8 passing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/memberStatusHelper.js test/utils/memberStatusHelper.test.js
+git commit -m "feat: add deriveMemberStatus precedence resolver"
+```
+
+---
+
+### Task 2: Data layer `teamService.getTeamMembersWithStatus`
+
+**Files:**
+- Modify: `src/services/teamService.js` (add method; add imports)
+- Test: `test/services/teamServiceMemberStatus.test.js`
+
+**Interfaces:**
+- Consumes: `getHolidayDateSet`, `isWorkingDayPure`, `getOrgDefaultWorkDays` from `src/utils/dateHelper`.
+- Produces: `async getTeamMembersWithStatus(teamId, date = null) → Array<{ user, role, teamActive, orgActive, receiveNotifications, onLeave, workingToday, responded }>`
+  - `date` defaults to today in the team's timezone.
+  - `user` is the full Prisma `User` (has `slackUserId`, `name`, `username`, `timezone`, `workDays`).
+  - Returns `[]` if the team has no members.
+
+Add these imports near the top of `teamService.js` (file already imports `prisma` from `../config/prisma`):
+
+```js
+const {
+  getHolidayDateSet,
+  isWorkingDayPure,
+  getOrgDefaultWorkDays,
+} = require("../utils/dateHelper");
+const dayjs = require("dayjs");
+const utc = require("dayjs/plugin/utc");
+const timezone = require("dayjs/plugin/timezone");
+dayjs.extend(utc);
+dayjs.extend(timezone);
+```
+
+> Note: if any of these (`dayjs`, the plugins, or a dateHelper import) are already imported in `teamService.js`, do not duplicate them — add only what's missing.
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// test/services/teamServiceMemberStatus.test.js
+jest.mock("../../src/config/prisma", () => ({
+  team: { findUnique: jest.fn() },
+  teamMember: { findMany: jest.fn() },
+  organizationMember: { findMany: jest.fn() },
+  standupResponse: { findMany: jest.fn() },
+  leave: { findMany: jest.fn() },
+  holiday: { findMany: jest.fn() },
+}));
+
+const prisma = require("../../src/config/prisma");
+const teamService = require("../../src/services/teamService");
+
+const team = {
+  id: "t1",
+  organizationId: "o1",
+  timezone: "America/New_York",
+  organization: { id: "o1", settings: { defaultWorkDays: [1, 2, 3, 4, 5] } },
+};
+
+// A fixed work-day Wednesday (ISO day 3) for deterministic workingToday.
+const WED = new Date("2026-06-24T12:00:00Z");
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  prisma.team.findUnique.mockResolvedValue(team);
+  prisma.holiday.findMany.mockResolvedValue([]);
+  prisma.organizationMember.findMany.mockResolvedValue([
+    { userId: "u1", isActive: true },
+    { userId: "u2", isActive: false },
+  ]);
+  prisma.standupResponse.findMany.mockResolvedValue([{ userId: "u1" }]);
+  prisma.leave.findMany.mockResolvedValue([{ userId: "u3" }]);
+  prisma.teamMember.findMany.mockResolvedValue([
+    {
+      role: "MEMBER",
+      isActive: true,
+      receiveNotifications: true,
+      userId: "u1",
+      user: { id: "u1", slackUserId: "U1", name: "Alice", workDays: [1, 2, 3, 4, 5] },
+    },
+    {
+      role: "MEMBER",
+      isActive: true,
+      receiveNotifications: false,
+      userId: "u2",
+      user: { id: "u2", slackUserId: "U2", name: "Bob", workDays: null },
+    },
+    {
+      role: "ADMIN",
+      isActive: true,
+      receiveNotifications: true,
+      userId: "u3",
+      user: { id: "u3", slackUserId: "U3", name: "Carol", workDays: null },
+    },
+  ]);
+});
+
+describe("getTeamMembersWithStatus", () => {
+  it("enriches each member with responded/onLeave/orgActive/workingToday", async () => {
+    const out = await teamService.getTeamMembersWithStatus("t1", WED);
+    const byId = Object.fromEntries(out.map((m) => [m.user.slackUserId, m]));
+
+    expect(byId.U1).toMatchObject({
+      role: "MEMBER",
+      teamActive: true,
+      orgActive: true,
+      receiveNotifications: true,
+      onLeave: false,
+      responded: true,
+      workingToday: true,
+    });
+    expect(byId.U2).toMatchObject({ orgActive: false, responded: false });
+    expect(byId.U3).toMatchObject({ role: "ADMIN", onLeave: true });
+  });
+
+  it("returns [] when the team has no members", async () => {
+    prisma.teamMember.findMany.mockResolvedValue([]);
+    expect(await teamService.getTeamMembersWithStatus("t1", WED)).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest test/services/teamServiceMemberStatus.test.js`
+Expected: FAIL — `teamService.getTeamMembersWithStatus is not a function`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add this method to the `TeamService` class in `src/services/teamService.js` (e.g. just after `getTeamMembers`):
+
+```js
+async getTeamMembersWithStatus(teamId, date = null) {
+  const team = await prisma.team.findUnique({
+    where: { id: teamId },
+    include: { organization: true },
+  });
+  if (!team) return [];
+
+  const targetDate = date
+    ? dayjs(date)
+    : dayjs().tz(team.timezone).startOf("day");
+  const startOfDay = targetDate.startOf("day").toDate();
+  const endOfDay = targetDate.endOf("day").toDate();
+
+  const members = await prisma.teamMember.findMany({
+    where: { teamId },
+    include: { user: true },
+  });
+  if (members.length === 0) return [];
+
+  const userIds = members.map((m) => m.userId);
+
+  const [orgMembers, responses, leaves, holidayDateSet] = await Promise.all([
+    prisma.organizationMember.findMany({
+      where: { organizationId: team.organizationId, userId: { in: userIds } },
+      select: { userId: true, isActive: true },
+    }),
+    prisma.standupResponse.findMany({
+      where: { teamId, standupDate: { gte: startOfDay, lte: endOfDay } },
+      select: { userId: true },
+    }),
+    prisma.leave.findMany({
+      where: {
+        userId: { in: userIds },
+        startDate: { lte: endOfDay },
+        endDate: { gte: startOfDay },
+      },
+      select: { userId: true },
+    }),
+    getHolidayDateSet(team.organizationId, startOfDay, endOfDay),
+  ]);
+
+  const orgActiveById = new Map(orgMembers.map((o) => [o.userId, o.isActive]));
+  const respondedIds = new Set(responses.map((r) => r.userId));
+  const onLeaveIds = new Set(leaves.map((l) => l.userId));
+  const orgDefaultWorkDays = getOrgDefaultWorkDays(team.organization?.settings);
+  const dateValue = targetDate.toDate();
+
+  return members.map((m) => {
+    const workDays = m.user.workDays?.length
+      ? m.user.workDays
+      : orgDefaultWorkDays;
+    return {
+      user: m.user,
+      role: m.role,
+      teamActive: m.isActive,
+      orgActive: orgActiveById.get(m.userId) ?? true,
+      receiveNotifications: m.receiveNotifications,
+      onLeave: onLeaveIds.has(m.userId),
+      workingToday: isWorkingDayPure({ date: dateValue, workDays, holidayDateSet }),
+      responded: respondedIds.has(m.userId),
+    };
+  });
+}
+```
+
+> The `Promise.all` here batches independent **reads of one team** — it is not the cross-team fan-out the repo prohibits. Callers still iterate teams sequentially.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest test/services/teamServiceMemberStatus.test.js`
+Expected: PASS (2 passing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/teamService.js test/services/teamServiceMemberStatus.test.js
+git commit -m "feat: add teamService.getTeamMembersWithStatus"
+```
+
+---
+
+### Task 3: Block helpers for both layouts
+
+**Files:**
+- Modify: `src/utils/blockHelper.js` (add two functions + exports)
+- Test: `test/utils/teamMemberStatusBlocks.test.js`
+
+**Interfaces:**
+- Consumes: `deriveMemberStatus` from `src/utils/memberStatusHelper`; `getDisplayName` from `src/utils/userHelper`; `formatTime12Hour` from `src/utils/dateHelper`; existing `createSectionBlock`, `createContextBlock` (same file).
+- Produces:
+  - `createTeamMembersStatusBlocks(team, members) → Block[]` — Option C, one section block per member.
+  - `createTeamListWithMembersBlocks({ heading, teams }) → Block[]` — Option A. `teams` is `Array<{ team, members }>`; one section block per team, a leading heading section, and a trailing legend context block.
+- `members` items are the enriched objects from Task 2.
+
+Note `blockHelper.js` already imports `createSectionBlock`/`createContextBlock` locally (defined in-file). Add at the top of `blockHelper.js`:
+
+```js
+const { deriveMemberStatus } = require("./memberStatusHelper");
+const { getDisplayName } = require("./userHelper");
+const { formatTime12Hour } = require("./dateHelper");
+```
+
+> If `getDisplayName` / `formatTime12Hour` are already imported in `blockHelper.js`, don't duplicate.
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// test/utils/teamMemberStatusBlocks.test.js
+const {
+  createTeamMembersStatusBlocks,
+  createTeamListWithMembersBlocks,
+} = require("../../src/utils/blockHelper");
+
+const team = {
+  name: "Engineering",
+  standupTime: "09:30",
+  postingTime: "10:00",
+  timezone: "America/New_York",
+};
+
+const members = [
+  { user: { slackUserId: "U1", name: "Alice" }, role: "ADMIN", teamActive: true, orgActive: true, receiveNotifications: true, onLeave: false, workingToday: true, responded: false },
+  { user: { slackUserId: "U2", name: "Bob" }, role: "MEMBER", teamActive: true, orgActive: true, receiveNotifications: false, onLeave: false, workingToday: true, responded: false },
+  { user: { slackUserId: "U3", name: "Carol" }, role: "MEMBER", teamActive: true, orgActive: true, receiveNotifications: true, onLeave: true, workingToday: true, responded: false },
+  { user: { slackUserId: "U4", name: "Dave" }, role: "MEMBER", teamActive: true, orgActive: true, receiveNotifications: true, onLeave: false, workingToday: true, responded: true },
+  { user: { slackUserId: "U5", name: "Eve" }, role: "MEMBER", teamActive: false, orgActive: true, receiveNotifications: true, onLeave: false, workingToday: true, responded: false },
+];
+
+function allText(blocks) {
+  return blocks
+    .map((b) => b.text?.text || (b.elements || []).map((e) => e.text).join(" "))
+    .join("\n");
+}
+
+describe("createTeamMembersStatusBlocks (Option C)", () => {
+  const blocks = createTeamMembersStatusBlocks(team, members);
+  const text = allText(blocks);
+
+  it("shows an active/inactive count header", () => {
+    expect(text).toContain("4 active");
+    expect(text).toContain("1 inactive");
+  });
+
+  it("suppresses standup for the admin but shows notifications + active", () => {
+    expect(text).toContain("👑 *Alice* (<@U1>) — Admin");
+    expect(text).not.toMatch(/Alice[\s\S]*Not submitted/);
+    expect(text).toContain("🔔 Notifications on");
+  });
+
+  it("renders pending, on-leave, submitted, and inactive", () => {
+    expect(text).toContain("⏳ Not submitted");
+    expect(text).toContain("🔕 Notifications off");
+    expect(text).toContain("🌴 On leave today");
+    expect(text).toContain("✅ Submitted today");
+    expect(text).toContain("💤 *Eve* (<@U5>) — Member");
+    expect(text).toContain("⚪ Inactive in team");
+  });
+});
+
+describe("createTeamListWithMembersBlocks (Option A)", () => {
+  const blocks = createTeamListWithMembersBlocks({
+    heading: "*📋 Your teams:*",
+    teams: [{ team, members }],
+  });
+  const text = allText(blocks);
+
+  it("keeps the per-team meta line", () => {
+    expect(text).toContain("*👥 Engineering");
+    expect(text).toContain("🔔 Reminder: 9:30 AM");
+    expect(text).toContain("📊 Posting: 10:00 AM");
+    expect(text).toContain("🌍 America/New_York");
+  });
+
+  it("renders compact member lines with status emoji", () => {
+    expect(text).toContain("👑 <@U1> · 🔔");
+    expect(text).toContain("👤 <@U2> · ⏳ · 🔕");
+    expect(text).toContain("👤 <@U3> · 🌴 · 🔔");
+    expect(text).toContain("👤 <@U4> · ✅ · 🔔");
+    expect(text).toContain("💤 <@U5> · inactive");
+  });
+
+  it("ends with a legend context block", () => {
+    const last = blocks[blocks.length - 1];
+    expect(last.type).toBe("context");
+    expect(last.elements[0].text).toContain("✅ submitted");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest test/utils/teamMemberStatusBlocks.test.js`
+Expected: FAIL — `createTeamMembersStatusBlocks is not a function`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `src/utils/blockHelper.js` (before `module.exports`):
+
+```js
+const STATUS_LABELS = {
+  leave: "🌴 On leave today",
+  submitted: "✅ Submitted today",
+  pending: "⏳ Not submitted",
+};
+const STATUS_EMOJI = { leave: "🌴", submitted: "✅", pending: "⏳" };
+
+// Option C — detailed two-line card per member.
+function createTeamMembersStatusBlocks(team, members) {
+  const activeCount = members.filter(
+    (m) => m.teamActive && m.orgActive
+  ).length;
+  const inactiveCount = members.length - activeCount;
+  const countLine =
+    inactiveCount > 0
+      ? `${activeCount} active · ${inactiveCount} inactive`
+      : `${activeCount} active`;
+
+  const blocks = [
+    createSectionBlock(`*👥 Members of "${team.name}"*\n${countLine}`),
+  ];
+
+  for (const m of members) {
+    const status = deriveMemberStatus(m);
+    const name = getDisplayName(m.user);
+    const roleLabel = m.role === "ADMIN" ? "Admin" : "Member";
+
+    if (!status.active) {
+      blocks.push(
+        createSectionBlock(
+          `💤 *${name}* (<@${m.user.slackUserId}>) — ${roleLabel}\n    ⚪ Inactive in ${status.inactiveScope}`
+        )
+      );
+      continue;
+    }
+
+    const roleIcon = m.role === "ADMIN" ? "👑" : "👤";
+    const parts = [];
+    if (status.standup) parts.push(STATUS_LABELS[status.standup]);
+    parts.push(
+      m.receiveNotifications ? "🔔 Notifications on" : "🔕 Notifications off"
+    );
+    parts.push("🟢 Active");
+
+    blocks.push(
+      createSectionBlock(
+        `${roleIcon} *${name}* (<@${m.user.slackUserId}>) — ${roleLabel}\n    ${parts.join(
+          "  ·  "
+        )}`
+      )
+    );
+  }
+
+  return blocks;
+}
+
+// Option A — compact one-line-per-member, nested under each team.
+function createTeamListWithMembersBlocks({ heading, teams }) {
+  const blocks = [createSectionBlock(heading)];
+
+  for (const { team, members } of teams) {
+    const meta =
+      `*👥 ${team.name} — ${members.length} members*\n` +
+      `🔔 Reminder: ${formatTime12Hour(team.standupTime)} | ` +
+      `📊 Posting: ${formatTime12Hour(team.postingTime)} | 🌍 ${team.timezone}`;
+
+    const lines = members.map((m) => {
+      const status = deriveMemberStatus(m);
+      if (!status.active) return `💤 <@${m.user.slackUserId}> · inactive`;
+      const roleIcon = m.role === "ADMIN" ? "👑" : "👤";
+      const parts = [`${roleIcon} <@${m.user.slackUserId}>`];
+      if (status.standup) parts.push(STATUS_EMOJI[status.standup]);
+      parts.push(m.receiveNotifications ? "🔔" : "🔕");
+      return parts.join(" · ");
+    });
+
+    blocks.push(createSectionBlock(`${meta}\n${lines.join("\n")}`));
+  }
+
+  blocks.push(
+    createContextBlock(
+      "✅ submitted · ⏳ not submitted · 🌴 on leave · 💤 inactive · 🔔/🔕 notifications on/off"
+    )
+  );
+
+  return blocks;
+}
+```
+
+Add both names to the `module.exports` object in `blockHelper.js`:
+
+```js
+  createTeamMembersStatusBlocks,
+  createTeamListWithMembersBlocks,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest test/utils/teamMemberStatusBlocks.test.js`
+Expected: PASS (all describe blocks green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/blockHelper.js test/utils/teamMemberStatusBlocks.test.js
+git commit -m "feat: add team member status block helpers (Options A & C)"
+```
+
+---
+
+### Task 4: Wire `listMembers` (`/dd-team-members`)
+
+**Files:**
+- Modify: `src/commands/team.js` — `listMembers` (lines ~321-390) and the `blockHelper` import block (lines ~8-12).
+
+**Interfaces:**
+- Consumes: `teamService.getTeamMembersWithStatus` (Task 2), `createTeamMembersStatusBlocks` (Task 3).
+
+This task is verified manually (the handler depends on Slack `ack`/`respond`); there is no unit test step. The deliverable is the wiring + a green full test run.
+
+- [ ] **Step 1: Add the import**
+
+In the `require("../utils/blockHelper")` destructure at the top of `team.js`, add `createTeamMembersStatusBlocks`:
+
+```js
+const {
+  createSectionBlock,
+  createCommandErrorBlocks,
+  createTeamApprovalResultBlocks,
+  createTeamMembersStatusBlocks,
+} = require("../utils/blockHelper");
+```
+
+- [ ] **Step 2: Replace the member-rendering body**
+
+In `listMembers`, replace the block that starts at `const members = await teamService.getTeamMembers(team.id);` through the `await updateResponse({ blocks: [ createSectionBlock(...) ] });` call with:
+
+```js
+    const members = await teamService.getTeamMembersWithStatus(team.id);
+
+    if (members.length === 0) {
+      await updateResponse({
+        text: `📋 No members found in team "${team.name}"`,
+      });
+      return;
+    }
+
+    await updateResponse({
+      blocks: createTeamMembersStatusBlocks(team, members),
+    });
+```
+
+(Leave the surrounding team-resolution and `try/catch` exactly as they are.)
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `npx jest`
+Expected: PASS — no regressions.
+
+- [ ] **Step 4: Manual check in Slack (note for executor)**
+
+Run `/dd-team-members` in a team channel and with an explicit team name. Confirm: admin shows no ✅/⏳; a submitted member shows ✅; an on-leave member shows 🌴; an inactive member shows 💤 + "Inactive in team/org"; the count line reads "N active · M inactive".
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commands/team.js
+git commit -m "feat: show member status in /dd-team-members"
+```
+
+---
+
+### Task 5: Wire `listTeams` (`/dd-team-list`)
+
+**Files:**
+- Modify: `src/commands/team.js` — `listTeams` (lines ~271-319) and the `blockHelper` import block.
+
+**Interfaces:**
+- Consumes: `teamService.getTeamMembersWithStatus` (Task 2), `createTeamListWithMembersBlocks` (Task 3).
+
+Manual-verified (Slack handler). Deliverable is wiring + green suite.
+
+- [ ] **Step 1: Add the import**
+
+Add `createTeamListWithMembersBlocks` to the same `blockHelper` destructure:
+
+```js
+  createTeamListWithMembersBlocks,
+```
+
+- [ ] **Step 2: Replace the team-rendering body**
+
+In `listTeams`, replace the block from `const teamList = teams.map(...)` through the final `await updateResponse({ blocks: [createSectionBlock(...)] });` with sequential per-team status fetching + the new helper:
+
+```js
+    const heading =
+      scope === "all"
+        ? `*📋 Teams in ${organization.name}:*`
+        : `*📋 Your teams:*`;
+
+    // Sequential, not parallel — avoid cross-team DB/Slack fan-out.
+    const teamsWithMembers = [];
+    for (const t of teams) {
+      const members = await teamService.getTeamMembersWithStatus(t.id);
+      teamsWithMembers.push({ team: t, members });
+    }
+
+    await updateResponse({
+      blocks: createTeamListWithMembersBlocks({
+        heading,
+        teams: teamsWithMembers,
+      }),
+    });
+```
+
+(Keep the empty-teams early return and the `try/catch` as they are. The `formatTime12Hour` import in `team.js` may become unused after this change — if so, remove it from the import line; if `formatTime12Hour` is still referenced elsewhere in the file, leave it.)
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `npx jest`
+Expected: PASS.
+
+- [ ] **Step 4: Lint (catch any now-unused import)**
+
+Run: `npm run lint`
+Expected: PASS — no `no-unused-vars` errors. Fix any flagged unused import created by this change only.
+
+- [ ] **Step 5: Manual check in Slack (note for executor)**
+
+Run `/dd-team-list` as a regular member (own teams) and as an org owner/admin (all teams). Confirm each team keeps its meta line, members appear compactly with status emoji, and the legend renders once at the bottom.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/commands/team.js
+git commit -m "feat: nest member status under teams in /dd-team-list"
+```
+
+---
+
+### Task 6: Documentation
+
+**Files:**
+- Modify: `README.md` (command descriptions for `/dd-team-list` and `/dd-team-members`)
+- Modify: `CHANGELOG.md` (technical entry under a new Unreleased/next-version section)
+- Modify: `web/src/data/changelog.json` (user-facing entry)
+
+Docs-only; verified by reading. No code test.
+
+- [ ] **Step 1: Update README**
+
+Find the `/dd-team-list` and `/dd-team-members` entries in `README.md` and note that both now show per-member status (today's standup, on-leave, notifications, role, active/inactive). Match the existing list formatting in that section.
+
+- [ ] **Step 2: Update CHANGELOG.md**
+
+Add under the top `Added` list (create an Unreleased section if the file's format uses one):
+
+```markdown
+- Member status in `/dd-team-list` (compact, nested per team) and `/dd-team-members` (detailed cards): today's standup, on-leave, notifications on/off, role, and active/inactive (team & org). Standup status is suppressed for admins and on non-work-days/holidays. New `deriveMemberStatus` resolver, `teamService.getTeamMembersWithStatus`, and `blockHelper` renderers.
+```
+
+- [ ] **Step 3: Update changelog.json**
+
+Add a user-facing entry (match the existing object shape in `web/src/data/changelog.json` — inspect the first entry for the exact keys/format before writing):
+
+```json
+{ "type": "added", "title": "See who's done their standup at a glance", "items": ["/dd-team-members now shows each member's status — submitted, not yet, on leave, notifications, and role.", "/dd-team-list lists members under each team with the same at-a-glance status."] }
+```
+
+- [ ] **Step 4: Verify formatting**
+
+Run: `npm run format:check` (or `npm run format` then re-stage) and confirm `web/src/data/changelog.json` is valid JSON: `node -e "require('./web/src/data/changelog.json')"`.
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md CHANGELOG.md web/src/data/changelog.json
+git commit -m "docs: document member status in team-list & team-members"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Status model / precedence → Task 1 (resolver) + Task 2 (facts). ✅
+- Suppress on non-work-days, holidays → Task 2 `workingToday` via `isWorkingDayPure`; Task 1 suppresses. ✅
+- Admins suppressed → Task 1. ✅
+- Show inactive (team & org) → Task 2 `teamActive`/`orgActive`; Task 1 `inactiveScope`; Tasks 3 render. ✅
+- `hideFromNotResponded` ignored → not queried anywhere (everyone listed). ✅
+- Option C for `/dd-team-members` → Tasks 3 + 4. ✅
+- Option A nested + meta line retained for `/dd-team-list` → Tasks 3 + 5. ✅
+- Per-team section blocks (3000-char limit) → Task 3 (`createTeamListWithMembersBlocks` emits one section per team). ✅
+- Sequential team processing → Task 5. ✅
+- Tests for resolver + block shape → Tasks 1, 3; service test Task 2. ✅
+- Docs (README, CHANGELOG.md, changelog.json) → Task 6. ✅
+
+**Placeholder scan:** No TBD/TODO; all steps contain concrete code/commands.
+
+**Type consistency:** `deriveMemberStatus` returns `{active, inactiveScope, standup}` — consumed identically in Tasks 1 and 3. Enriched member shape `{user, role, teamActive, orgActive, receiveNotifications, onLeave, workingToday, responded}` produced in Task 2, consumed in Tasks 1 & 3. `createTeamListWithMembersBlocks({heading, teams})` signature matches Task 5's call. ✅

--- a/docs/superpowers/specs/2026-06-23-member-status-in-team-commands-design.md
+++ b/docs/superpowers/specs/2026-06-23-member-status-in-team-commands-design.md
@@ -1,0 +1,131 @@
+# Member status in `/dd-team-list` & `/dd-team-members`
+
+**Date:** 2026-06-23
+**Status:** Approved (design)
+
+## Goal
+
+Surface each team member's current status in two existing Slack commands:
+
+- **`/dd-team-members`** (`listMembers`) — detailed, two-line "card" per member (Option C).
+- **`/dd-team-list`** (`listTeams`) — keep the existing per-team meta line, with a compact one-line-per-member list nested under each team (Option A).
+
+"Status" means: today's standup (submitted / not), on leave today, notifications on/off, role, and active/inactive (team **and** org).
+
+## Status model (shared)
+
+Resolved per member for **today's date in the team's timezone**. Exactly one _primary_ badge, plus _secondary_ flags.
+
+Precedence (top-down — first match wins):
+
+| Condition                                                                                       | Primary badge          |
+| ----------------------------------------------------------------------------------------------- | ---------------------- |
+| Inactive in team (`TeamMember.isActive=false`) **or** org (`OrganizationMember.isActive=false`) | `💤 inactive`          |
+| On leave today (a `Leave` row overlaps today)                                                   | `🌴 on leave`          |
+| Role is `ADMIN`                                                                                 | _(standup suppressed)_ |
+| Today is not a work day for them, or an org holiday                                             | _(standup suppressed)_ |
+| Submitted a `StandupResponse` for today (late or on-time)                                       | `✅ submitted`         |
+| Otherwise                                                                                       | `⏳ not submitted`     |
+
+Secondary flags (shown for active members):
+
+- Role: `👑` admin / `👤` member.
+- Notifications: `🔔` on / `🔕` off (`TeamMember.receiveNotifications`).
+
+Display rules:
+
+- **Inactive** members show role + `💤` only — no standup/notification noise.
+- **Admins** and **non-working-day** members show role + notifications + active, but **no** `✅`/`⏳` (admins are not expected to submit, consistent with reminder/summary behavior elsewhere).
+
+### `hideFromNotResponded`
+
+Explicitly **ignored** here. That flag only hides a member from the "not responded" list in _posted summaries_; these commands are an explicit "show me the members" view, so everyone is listed.
+
+## Data layer — `teamService.getTeamMembersWithStatus(teamId, date)`
+
+One new method returning enriched members. Steps:
+
+1. Fetch **all** team members including inactive (drop the current `isActive: true` filter used by `getTeamMembers`), `include: { user: true }`.
+2. Fetch `OrganizationMember` (`isActive`) for the team's org → map by `userId`.
+3. Build `respondedUserIds` from `StandupResponse` for `teamId` + today (**any `isLate`** — cannot reuse `getTeamResponses`, which filters `isLate: false`).
+4. Build `onLeaveUserIds` via the existing leave-overlap query pattern (`startDate <= today <= endDate`).
+5. Compute `workingToday` per member via `getHolidayDateSet(orgId, today, today)` + `isWorkingDayPure({ date, workDays, holidayDateSet })`, matching reminder gating. Members with no `workDays` fall back to the org default (same as reminders).
+
+Returns an array of plain objects:
+
+```js
+{
+  user,                  // includes slackUserId, name/username, timezone
+  role,                  // 'ADMIN' | 'MEMBER'
+  teamActive,            // TeamMember.isActive
+  orgActive,             // OrganizationMember.isActive (default true if no row)
+  receiveNotifications,
+  onLeave,               // bool
+  workingToday,          // bool
+  responded,             // bool
+}
+```
+
+### Pure resolver — `deriveMemberStatus(member)`
+
+A standalone, DB-free function applying the precedence table above and returning a small descriptor, e.g.:
+
+```js
+{ active: bool, primary: 'inactive'|'leave'|'submitted'|'pending'|'none', showStandup: bool }
+```
+
+Kept separate so every precedence branch is unit-testable without the database.
+
+## Display layer — `src/utils/blockHelper.js`
+
+Per repo rule, all Block Kit lives here (no inline blocks at call sites).
+
+- **`createTeamMembersStatusBlocks(team, members)`** — Option C, labeled two-line cards. Self-documenting; no legend needed. Member count line: `N active · M inactive`.
+
+  ```
+  👑 *Alice* (@alice) — Admin
+      🔔 Notifications on  ·  🟢 Active
+
+  👤 *Bob* (@bob) — Member
+      ⏳ Not submitted  ·  🔕 Notifications off  ·  🟢 Active
+
+  👤 *Carol* (@carol) — Member
+      🌴 On leave today  ·  🔔 Notifications on  ·  🟢 Active
+
+  💤 *Eve* (@eve) — Member
+      ⚪ Inactive in team
+  ```
+
+- **`createTeamListWithMembersBlocks(...)`** — Option A. **One section block per team** (avoids the 3000-char section limit), existing meta line (member count + reminder/posting/timezone) retained, compact member lines beneath, plus one trailing **context-block legend** (Option A is emoji-only).
+
+  ```
+  *👥 Engineering — 5 members*
+  🔔 Reminder: 9:30 AM | 📊 Posting: 10:00 AM | 🌍 America/New_York
+  👑 @alice · ✅ · 🔔
+  👤 @bob · ⏳ · 🔕
+  👤 @carol · 🌴 · 🔔
+  💤 @eve · inactive
+  ```
+
+## Command wiring — `src/commands/team.js`
+
+- **`listMembers`** — call `getTeamMembersWithStatus`, render with `createTeamMembersStatusBlocks`. Empty-team and all-inactive cases handled.
+- **`listTeams`** — for each team **sequentially** (no parallel DB/Slack fan-out, per repo rule), call `getTeamMembersWithStatus`, render nested Option A via `createTeamListWithMembersBlocks`. The existing meta line is preserved.
+
+## Edge cases
+
+- Empty team / all-inactive team.
+- Org holiday today (standup suppressed for all).
+- Member with no `workDays` (falls back to org default).
+- `/dd-team-list` "all teams" scope can be large → per-team section blocks keep each block under limits.
+
+## Out of scope / no change
+
+- No new permission gate (neither command has one today; the only newly exposed field is per-member notification on/off — leave and responded status are already public via posted summaries).
+- No `deletedAt` filtering beyond existing patterns (current leave/response queries don't filter it; match that).
+- No Slack manifest change (no new command).
+
+## Tests & docs
+
+- **Jest** unit tests for `deriveMemberStatus` (every precedence branch: inactive-team, inactive-org, on-leave, admin, non-work-day, submitted, not-submitted) and the block-helper output shape.
+- Update `README.md`, `CHANGELOG.md`, and `web/src/data/changelog.json` (user-facing commands).

--- a/src/commands/team.js
+++ b/src/commands/team.js
@@ -3,12 +3,12 @@ const userService = require("../services/userService");
 const schedulerService = require("../services/schedulerService");
 const notificationService = require("../services/notificationService");
 const { ackWithProcessing, getChannelName } = require("../utils/commandHelper");
-const { getDisplayName } = require("../utils/userHelper");
 const { formatTime12Hour } = require("../utils/dateHelper");
 const {
-  createSectionBlock,
   createCommandErrorBlocks,
   createTeamApprovalResultBlocks,
+  createTeamMembersStatusBlocks,
+  createTeamListWithMembersBlocks,
 } = require("../utils/blockHelper");
 const logger = require("../utils/logger");
 const { parseTimeString } = require("../utils/timeHelper");
@@ -290,26 +290,23 @@ async function listTeams({ command, ack, respond }) {
       return;
     }
 
-    const teamList = teams
-      .map(
-        (t) =>
-          `• *${t.name}* (${
-            t._count.members
-          } members)\n  🔔 Reminder: ${formatTime12Hour(
-            t.standupTime
-          )} | 📊 Posting: ${formatTime12Hour(t.postingTime)} | 🌍 ${
-            t.timezone
-          }`
-      )
-      .join("\n\n");
-
     const heading =
       scope === "all"
         ? `*📋 Teams in ${organization.name}:*`
         : `*📋 Your teams:*`;
 
+    // Sequential, not parallel — avoid cross-team DB/Slack fan-out.
+    const teamsWithMembers = [];
+    for (const t of teams) {
+      const members = await teamService.getTeamMembersWithStatus(t.id);
+      teamsWithMembers.push({ team: t, members });
+    }
+
     await updateResponse({
-      blocks: [createSectionBlock(`${heading}\n\n${teamList}`)],
+      blocks: createTeamListWithMembersBlocks({
+        heading,
+        teams: teamsWithMembers,
+      }),
     });
   } catch (error) {
     await updateResponse({
@@ -355,8 +352,8 @@ async function listMembers({ command, ack, respond }) {
       }
     }
 
-    // Get team members
-    const members = await teamService.getTeamMembers(team.id);
+    // Get team members with status
+    const members = await teamService.getTeamMembersWithStatus(team.id);
 
     if (members.length === 0) {
       await updateResponse({
@@ -365,22 +362,8 @@ async function listMembers({ command, ack, respond }) {
       return;
     }
 
-    const memberList = members
-      .map((member) => {
-        const roleIcon = member.role === "ADMIN" ? "👑" : "👤";
-        const displayName = getDisplayName(member.user);
-        return `${roleIcon} <@${
-          member.user.slackUserId
-        }> (${displayName}) - ${member.role.toLowerCase()}`;
-      })
-      .join("\n");
-
     await updateResponse({
-      blocks: [
-        createSectionBlock(
-          `*👥 Members of team "${team.name}":*\n${memberList}`
-        ),
-      ],
+      blocks: createTeamMembersStatusBlocks(team, members),
     });
   } catch (error) {
     await updateResponse({

--- a/src/commands/team.js
+++ b/src/commands/team.js
@@ -295,12 +295,16 @@ async function listTeams({ command, ack, respond }) {
         ? `*📋 Teams in ${organization.name}:*`
         : `*📋 Your teams:*`;
 
-    // Sequential, not parallel — avoid cross-team DB/Slack fan-out.
-    const teamsWithMembers = [];
-    for (const t of teams) {
-      const members = await teamService.getTeamMembersWithStatus(t.id);
-      teamsWithMembers.push({ team: t, members });
-    }
+    // Batched: one constant set of DB reads for all teams (same org), instead
+    // of a per-team query fan-out.
+    const membersByTeam = await teamService.getMembersWithStatusByTeam(
+      teams,
+      organization
+    );
+    const teamsWithMembers = teams.map((t) => ({
+      team: t,
+      members: membersByTeam.get(t.id) ?? [],
+    }));
 
     await updateResponse({
       blocks: createTeamListWithMembersBlocks({
@@ -341,8 +345,20 @@ async function listMembers({ command, ack, respond }) {
         return;
       }
     } else {
-      // Find team by name across all organizations
-      team = await teamService.findTeamByName(teamName);
+      // Find team by name within the caller's own organization only — never
+      // across orgs, so member status (leave, standup, notifications) can't be
+      // disclosed cross-tenant.
+      const userOrg = await userService.getUserOrganization(command.user_id);
+      if (!userOrg) {
+        await updateResponse({
+          blocks: createCommandErrorBlocks(
+            "You are not a member of any organization."
+          ),
+        });
+        return;
+      }
+
+      team = await teamService.findTeamByName(teamName, userOrg.id);
 
       if (!team) {
         await updateResponse({

--- a/src/services/teamService.js
+++ b/src/services/teamService.js
@@ -398,74 +398,129 @@ class TeamService {
     });
     if (!team) return [];
 
-    // Mirror standupService.getActiveMembers: use the current instant (in the
-    // team's timezone), NOT startOf("day"). isWorkingDayPure/getHolidayDateSet
-    // resolve the calendar day from this instant via getDayOfWeekIso (local) +
-    // toIsoDate (UTC); a team-local midnight instant would resolve to the wrong
-    // day for off-UTC teams. Keeping the instant matches how "responded today"
-    // is stored and queried elsewhere.
-    const dateValue = date
-      ? dayjs(date).toDate()
-      : dayjs().tz(team.timezone).toDate();
-    const startOfDay = dayjs(dateValue).startOf("day").toDate();
-    const endOfDay = dayjs(dateValue).endOf("day").toDate();
+    const byTeam = await this.getMembersWithStatusByTeam(
+      [team],
+      team.organization,
+      date
+    );
+    return byTeam.get(team.id) ?? [];
+  }
 
+  /**
+   * Batched status for many teams of the SAME organization in a constant number
+   * of queries (avoids the N×6 fan-out of calling getTeamMembersWithStatus in a
+   * loop). Returns a Map<teamId, statusMember[]>.
+   *
+   * "Today" is resolved per team in that team's own timezone as a calendar day
+   * (YYYY-MM-DD): the day window for responded/leave uses UTC midnight bounds of
+   * that local day (standupDate/leave are @db.Date stored at UTC midnight), and
+   * the work-day/holiday check uses noon-UTC of that day so getDayOfWeekIso
+   * (server-local) and toIsoDate (UTC) agree on the calendar day.
+   *
+   * @param {Array<Object>} teams - team rows (id, timezone, ...) of one org
+   * @param {Object} organization - shared org (id, settings)
+   * @param {Date|null} date - override "today" (calendar day); defaults per team
+   * @returns {Promise<Map<string, Array<Object>>>}
+   */
+  async getMembersWithStatusByTeam(teams, organization, date = null) {
+    const byTeam = new Map(teams.map((t) => [t.id, []]));
+    if (teams.length === 0) return byTeam;
+
+    // Per-team calendar day + UTC bounds.
+    const dayByTeam = new Map();
+    for (const t of teams) {
+      const localDateStr = date
+        ? dayjs(date).format("YYYY-MM-DD")
+        : dayjs().tz(t.timezone).format("YYYY-MM-DD");
+      dayByTeam.set(t.id, {
+        dateValue: dayjs.utc(`${localDateStr}T12:00:00`).toDate(),
+        startOfDay: dayjs.utc(localDateStr).startOf("day").toDate(),
+        endOfDay: dayjs.utc(localDateStr).endOf("day").toDate(),
+      });
+    }
+    const bounds = [...dayByTeam.values()];
+    const rangeStart = new Date(
+      Math.min(...bounds.map((b) => b.startOfDay.getTime()))
+    );
+    const rangeEnd = new Date(
+      Math.max(...bounds.map((b) => b.endOfDay.getTime()))
+    );
+
+    const teamIds = teams.map((t) => t.id);
+    // ADMIN before MEMBER, then by name, so truncated views drop deterministically.
     const members = await prisma.teamMember.findMany({
-      where: { teamId },
+      where: { teamId: { in: teamIds } },
       include: { user: true },
+      orderBy: [{ role: "asc" }, { user: { name: "asc" } }],
     });
-    if (members.length === 0) return [];
+    if (members.length === 0) return byTeam;
 
-    const userIds = members.map((m) => m.userId);
+    const userIds = [...new Set(members.map((m) => m.userId))];
 
     const [orgMembers, responses, leaves, holidayDateSet] = await Promise.all([
       prisma.organizationMember.findMany({
-        where: { organizationId: team.organizationId, userId: { in: userIds } },
+        where: { organizationId: organization.id, userId: { in: userIds } },
         select: { userId: true, isActive: true },
       }),
       prisma.standupResponse.findMany({
-        where: { teamId, standupDate: { gte: startOfDay, lte: endOfDay } },
-        select: { userId: true },
+        where: {
+          teamId: { in: teamIds },
+          standupDate: { gte: rangeStart, lte: rangeEnd },
+        },
+        select: { teamId: true, userId: true, standupDate: true },
       }),
       prisma.leave.findMany({
         where: {
           userId: { in: userIds },
-          startDate: { lte: endOfDay },
-          endDate: { gte: startOfDay },
+          startDate: { lte: rangeEnd },
+          endDate: { gte: rangeStart },
         },
-        select: { userId: true },
+        select: { userId: true, startDate: true, endDate: true },
       }),
-      getHolidayDateSet(team.organizationId, startOfDay, endOfDay),
+      getHolidayDateSet(organization.id, rangeStart, rangeEnd),
     ]);
 
     const orgActiveById = new Map(
       orgMembers.map((o) => [o.userId, o.isActive])
     );
-    const respondedIds = new Set(responses.map((r) => r.userId));
-    const onLeaveIds = new Set(leaves.map((l) => l.userId));
-    const orgDefaultWorkDays = getOrgDefaultWorkDays(
-      team.organization?.settings
-    );
+    const orgDefaultWorkDays = getOrgDefaultWorkDays(organization?.settings);
 
-    return members.map((m) => {
+    for (const m of members) {
+      const day = dayByTeam.get(m.teamId);
+      const responded = responses.some(
+        (r) =>
+          r.teamId === m.teamId &&
+          r.userId === m.userId &&
+          r.standupDate >= day.startOfDay &&
+          r.standupDate <= day.endOfDay
+      );
+      const onLeave = leaves.some(
+        (l) =>
+          l.userId === m.userId &&
+          l.startDate <= day.endOfDay &&
+          l.endDate >= day.startOfDay
+      );
       const workDays = m.user.workDays?.length
         ? m.user.workDays
         : orgDefaultWorkDays;
-      return {
+      byTeam.get(m.teamId).push({
         user: m.user,
         role: m.role,
         teamActive: m.isActive,
-        orgActive: orgActiveById.get(m.userId) ?? true,
+        // Every team member should have an org membership row; treat a missing
+        // one as inactive so the data gap surfaces rather than reading "Active".
+        orgActive: orgActiveById.get(m.userId) ?? false,
         receiveNotifications: m.receiveNotifications,
-        onLeave: onLeaveIds.has(m.userId),
+        onLeave,
         workingToday: isWorkingDayPure({
-          date: dateValue,
+          date: day.dateValue,
           workDays,
           holidayDateSet,
         }),
-        responded: respondedIds.has(m.userId),
-      };
-    });
+        responded,
+      });
+    }
+    return byTeam;
   }
 
   async getTeamAdmins(teamId) {

--- a/src/services/teamService.js
+++ b/src/services/teamService.js
@@ -398,11 +398,17 @@ class TeamService {
     });
     if (!team) return [];
 
-    const targetDate = date
-      ? dayjs(date)
-      : dayjs().tz(team.timezone).startOf("day");
-    const startOfDay = targetDate.startOf("day").toDate();
-    const endOfDay = targetDate.endOf("day").toDate();
+    // Mirror standupService.getActiveMembers: use the current instant (in the
+    // team's timezone), NOT startOf("day"). isWorkingDayPure/getHolidayDateSet
+    // resolve the calendar day from this instant via getDayOfWeekIso (local) +
+    // toIsoDate (UTC); a team-local midnight instant would resolve to the wrong
+    // day for off-UTC teams. Keeping the instant matches how "responded today"
+    // is stored and queried elsewhere.
+    const dateValue = date
+      ? dayjs(date).toDate()
+      : dayjs().tz(team.timezone).toDate();
+    const startOfDay = dayjs(dateValue).startOf("day").toDate();
+    const endOfDay = dayjs(dateValue).endOf("day").toDate();
 
     const members = await prisma.teamMember.findMany({
       where: { teamId },
@@ -440,7 +446,6 @@ class TeamService {
     const orgDefaultWorkDays = getOrgDefaultWorkDays(
       team.organization?.settings
     );
-    const dateValue = targetDate.toDate();
 
     return members.map((m) => {
       const workDays = m.user.workDays?.length

--- a/src/services/teamService.js
+++ b/src/services/teamService.js
@@ -4,10 +4,19 @@ const channelService = require("./channelService");
 const permissionHelper = require("../utils/permissionHelper");
 const { UserFacingError } = require("../utils/errorHelper");
 const { validateTimezone } = require("../utils/timeHelper");
+const {
+  getHolidayDateSet,
+  isWorkingDayPure,
+  getOrgDefaultWorkDays,
+} = require("../utils/dateHelper");
 const dayjs = require("dayjs");
 const customParseFormat = require("dayjs/plugin/customParseFormat");
+const utc = require("dayjs/plugin/utc");
+const timezone = require("dayjs/plugin/timezone");
 
 dayjs.extend(customParseFormat);
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 // Helper function to validate and convert time string to Date object
 function validateTimeString(timeString) {
@@ -379,6 +388,78 @@ class TeamService {
       include: {
         user: true,
       },
+    });
+  }
+
+  async getTeamMembersWithStatus(teamId, date = null) {
+    const team = await prisma.team.findUnique({
+      where: { id: teamId },
+      include: { organization: true },
+    });
+    if (!team) return [];
+
+    const targetDate = date
+      ? dayjs(date)
+      : dayjs().tz(team.timezone).startOf("day");
+    const startOfDay = targetDate.startOf("day").toDate();
+    const endOfDay = targetDate.endOf("day").toDate();
+
+    const members = await prisma.teamMember.findMany({
+      where: { teamId },
+      include: { user: true },
+    });
+    if (members.length === 0) return [];
+
+    const userIds = members.map((m) => m.userId);
+
+    const [orgMembers, responses, leaves, holidayDateSet] = await Promise.all([
+      prisma.organizationMember.findMany({
+        where: { organizationId: team.organizationId, userId: { in: userIds } },
+        select: { userId: true, isActive: true },
+      }),
+      prisma.standupResponse.findMany({
+        where: { teamId, standupDate: { gte: startOfDay, lte: endOfDay } },
+        select: { userId: true },
+      }),
+      prisma.leave.findMany({
+        where: {
+          userId: { in: userIds },
+          startDate: { lte: endOfDay },
+          endDate: { gte: startOfDay },
+        },
+        select: { userId: true },
+      }),
+      getHolidayDateSet(team.organizationId, startOfDay, endOfDay),
+    ]);
+
+    const orgActiveById = new Map(
+      orgMembers.map((o) => [o.userId, o.isActive])
+    );
+    const respondedIds = new Set(responses.map((r) => r.userId));
+    const onLeaveIds = new Set(leaves.map((l) => l.userId));
+    const orgDefaultWorkDays = getOrgDefaultWorkDays(
+      team.organization?.settings
+    );
+    const dateValue = targetDate.toDate();
+
+    return members.map((m) => {
+      const workDays = m.user.workDays?.length
+        ? m.user.workDays
+        : orgDefaultWorkDays;
+      return {
+        user: m.user,
+        role: m.role,
+        teamActive: m.isActive,
+        orgActive: orgActiveById.get(m.userId) ?? true,
+        receiveNotifications: m.receiveNotifications,
+        onLeave: onLeaveIds.has(m.userId),
+        workingToday: isWorkingDayPure({
+          date: dateValue,
+          workDays,
+          holidayDateSet,
+        }),
+        responded: respondedIds.has(m.userId),
+      };
     });
   }
 

--- a/src/utils/blockHelper.js
+++ b/src/utils/blockHelper.js
@@ -3,6 +3,9 @@
  */
 
 const { convertTextToRichText, escapeSlackText } = require("./messageHelper");
+const { deriveMemberStatus } = require("./memberStatusHelper");
+const { getDisplayName } = require("./userHelper");
+const { formatTime12Hour } = require("./dateHelper");
 
 /**
  * Create a basic section block with markdown text
@@ -885,8 +888,96 @@ function createChangelogBroadcastBlocks(versionEntry, changelogUrl) {
   return blocks;
 }
 
+const STATUS_LABELS = {
+  leave: "🌴 On leave today",
+  submitted: "✅ Submitted today",
+  pending: "⏳ Not submitted",
+};
+const STATUS_EMOJI = { leave: "🌴", submitted: "✅", pending: "⏳" };
+
+// Option C — detailed two-line card per member.
+function createTeamMembersStatusBlocks(team, members) {
+  const activeCount = members.filter((m) => m.teamActive && m.orgActive).length;
+  const inactiveCount = members.length - activeCount;
+  const countLine =
+    inactiveCount > 0
+      ? `${activeCount} active · ${inactiveCount} inactive`
+      : `${activeCount} active`;
+
+  const blocks = [
+    createSectionBlock(`*👥 Members of "${team.name}"*\n${countLine}`),
+  ];
+
+  for (const m of members) {
+    const status = deriveMemberStatus(m);
+    const name = getDisplayName(m.user);
+    const roleLabel = m.role === "ADMIN" ? "Admin" : "Member";
+
+    if (!status.active) {
+      blocks.push(
+        createSectionBlock(
+          `💤 *${name}* (<@${m.user.slackUserId}>) — ${roleLabel}\n    ⚪ Inactive in ${status.inactiveScope}`
+        )
+      );
+      continue;
+    }
+
+    const roleIcon = m.role === "ADMIN" ? "👑" : "👤";
+    const parts = [];
+    if (status.standup) parts.push(STATUS_LABELS[status.standup]);
+    parts.push(
+      m.receiveNotifications ? "🔔 Notifications on" : "🔕 Notifications off"
+    );
+    parts.push("🟢 Active");
+
+    blocks.push(
+      createSectionBlock(
+        `${roleIcon} *${name}* (<@${m.user.slackUserId}>) — ${roleLabel}\n    ${parts.join(
+          "  ·  "
+        )}`
+      )
+    );
+  }
+
+  return blocks;
+}
+
+// Option A — compact one-line-per-member, nested under each team.
+function createTeamListWithMembersBlocks({ heading, teams }) {
+  const blocks = [createSectionBlock(heading)];
+
+  for (const { team, members } of teams) {
+    const meta =
+      `*👥 ${team.name} — ${members.length} members*\n` +
+      `🔔 Reminder: ${formatTime12Hour(team.standupTime)} | ` +
+      `📊 Posting: ${formatTime12Hour(team.postingTime)} | 🌍 ${team.timezone}`;
+
+    const lines = members.map((m) => {
+      const status = deriveMemberStatus(m);
+      if (!status.active) return `💤 <@${m.user.slackUserId}> · inactive`;
+      const roleIcon = m.role === "ADMIN" ? "👑" : "👤";
+      const parts = [`${roleIcon} <@${m.user.slackUserId}>`];
+      if (status.standup) parts.push(STATUS_EMOJI[status.standup]);
+      parts.push(m.receiveNotifications ? "🔔" : "🔕");
+      return parts.join(" · ");
+    });
+
+    blocks.push(createSectionBlock(`${meta}\n${lines.join("\n")}`));
+  }
+
+  blocks.push(
+    createContextBlock(
+      "✅ submitted · ⏳ not submitted · 🌴 on leave · 💤 inactive · 🔔/🔕 notifications on/off"
+    )
+  );
+
+  return blocks;
+}
+
 module.exports = {
   createSectionBlock,
+  createTeamMembersStatusBlocks,
+  createTeamListWithMembersBlocks,
   createChangelogBroadcastBlocks,
   createFieldsBlock,
   createTaskFieldBlocks,

--- a/src/utils/blockHelper.js
+++ b/src/utils/blockHelper.js
@@ -895,6 +895,13 @@ const STATUS_LABELS = {
 };
 const STATUS_EMOJI = { leave: "🌴", submitted: "✅", pending: "⏳" };
 
+// Slack caps a message at 50 blocks. Option C emits one block per member plus
+// a header (and a footer when truncated), so cap the member cards.
+const MAX_MEMBER_CARDS = 47;
+// Option A: heading + one block per team + legend (+ a footer when truncated)
+// must stay within the 50-block cap.
+const MAX_TEAM_BLOCKS = 47;
+
 // Option C — detailed two-line card per member.
 function createTeamMembersStatusBlocks(team, members) {
   const activeCount = members.filter((m) => m.teamActive && m.orgActive).length;
@@ -908,7 +915,10 @@ function createTeamMembersStatusBlocks(team, members) {
     createSectionBlock(`*👥 Members of "${team.name}"*\n${countLine}`),
   ];
 
-  for (const m of members) {
+  const shownMembers = members.slice(0, MAX_MEMBER_CARDS);
+  const hiddenMembers = members.length - shownMembers.length;
+
+  for (const m of shownMembers) {
     const status = deriveMemberStatus(m);
     const name = getDisplayName(m.user);
     const roleLabel = m.role === "ADMIN" ? "Admin" : "Member";
@@ -939,14 +949,42 @@ function createTeamMembersStatusBlocks(team, members) {
     );
   }
 
+  if (hiddenMembers > 0) {
+    blocks.push(
+      createContextBlock(
+        `➕ ${hiddenMembers} more member${hiddenMembers === 1 ? "" : "s"} not shown (Slack limits this view).`
+      )
+    );
+  }
+
   return blocks;
+}
+
+// Build a team's section text, dropping trailing member lines if the joined
+// text would exceed the 3000-char section limit.
+function fitTeamSection(meta, lines) {
+  const reserve = 40; // room for the "…and N more" suffix
+  let budget = SLACK_TEXT_MAX - meta.length - reserve;
+  const kept = [];
+  for (const line of lines) {
+    if (budget - (line.length + 1) < 0) break;
+    kept.push(line);
+    budget -= line.length + 1;
+  }
+  const hidden = lines.length - kept.length;
+  let text = kept.length ? `${meta}\n${kept.join("\n")}` : meta;
+  if (hidden > 0) text += `\n_…and ${hidden} more_`;
+  return text;
 }
 
 // Option A — compact one-line-per-member, nested under each team.
 function createTeamListWithMembersBlocks({ heading, teams }) {
   const blocks = [createSectionBlock(heading)];
 
-  for (const { team, members } of teams) {
+  const shownTeams = teams.slice(0, MAX_TEAM_BLOCKS);
+  const hiddenTeams = teams.length - shownTeams.length;
+
+  for (const { team, members } of shownTeams) {
     const meta =
       `*👥 ${team.name} — ${members.length} members*\n` +
       `🔔 Reminder: ${formatTime12Hour(team.standupTime)} | ` +
@@ -962,7 +1000,15 @@ function createTeamListWithMembersBlocks({ heading, teams }) {
       return parts.join(" · ");
     });
 
-    blocks.push(createSectionBlock(`${meta}\n${lines.join("\n")}`));
+    blocks.push(createSectionBlock(fitTeamSection(meta, lines)));
+  }
+
+  if (hiddenTeams > 0) {
+    blocks.push(
+      createContextBlock(
+        `➕ ${hiddenTeams} more team${hiddenTeams === 1 ? "" : "s"} not shown (Slack limits this view).`
+      )
+    );
   }
 
   blocks.push(

--- a/src/utils/blockHelper.js
+++ b/src/utils/blockHelper.js
@@ -893,7 +893,9 @@ const STATUS_LABELS = {
   submitted: "✅ Submitted today",
   pending: "⏳ Not submitted",
 };
-const STATUS_EMOJI = { leave: "🌴", submitted: "✅", pending: "⏳" };
+// The compact view shows just the leading emoji; derive it so the two views
+// can't drift out of sync.
+const statusEmoji = (standup) => STATUS_LABELS[standup].split(" ")[0];
 
 // Slack caps a message at 50 blocks. Option C emits one block per member plus
 // a header (and a footer when truncated), so cap the member cards.
@@ -904,7 +906,9 @@ const MAX_TEAM_BLOCKS = 47;
 
 // Option C — detailed two-line card per member.
 function createTeamMembersStatusBlocks(team, members) {
-  const activeCount = members.filter((m) => m.teamActive && m.orgActive).length;
+  const activeCount = members.filter(
+    (m) => deriveMemberStatus(m).active
+  ).length;
   const inactiveCount = members.length - activeCount;
   const countLine =
     inactiveCount > 0
@@ -912,7 +916,9 @@ function createTeamMembersStatusBlocks(team, members) {
       : `${activeCount} active`;
 
   const blocks = [
-    createSectionBlock(`*👥 Members of "${team.name}"*\n${countLine}`),
+    createSectionBlock(
+      `*👥 Members of "${escapeSlackText(team.name)}"*\n${countLine}`
+    ),
   ];
 
   const shownMembers = members.slice(0, MAX_MEMBER_CARDS);
@@ -920,7 +926,7 @@ function createTeamMembersStatusBlocks(team, members) {
 
   for (const m of shownMembers) {
     const status = deriveMemberStatus(m);
-    const name = getDisplayName(m.user);
+    const name = escapeSlackText(getDisplayName(m.user));
     const roleLabel = m.role === "ADMIN" ? "Admin" : "Member";
 
     if (!status.active) {
@@ -974,7 +980,8 @@ function fitTeamSection(meta, lines) {
   const hidden = lines.length - kept.length;
   let text = kept.length ? `${meta}\n${kept.join("\n")}` : meta;
   if (hidden > 0) text += `\n_…and ${hidden} more_`;
-  return text;
+  // Final hard clamp: guarantees ≤ SLACK_TEXT_MAX even when meta alone is huge.
+  return truncateForSlack(text, SLACK_TEXT_MAX);
 }
 
 // Option A — compact one-line-per-member, nested under each team.
@@ -986,7 +993,7 @@ function createTeamListWithMembersBlocks({ heading, teams }) {
 
   for (const { team, members } of shownTeams) {
     const meta =
-      `*👥 ${team.name} — ${members.length} members*\n` +
+      `*👥 ${escapeSlackText(team.name)} — ${members.length} members*\n` +
       `🔔 Reminder: ${formatTime12Hour(team.standupTime)} | ` +
       `📊 Posting: ${formatTime12Hour(team.postingTime)} | 🌍 ${team.timezone}`;
 
@@ -995,7 +1002,7 @@ function createTeamListWithMembersBlocks({ heading, teams }) {
       if (!status.active) return `💤 <@${m.user.slackUserId}> · inactive`;
       const roleIcon = m.role === "ADMIN" ? "👑" : "👤";
       const parts = [`${roleIcon} <@${m.user.slackUserId}>`];
-      if (status.standup) parts.push(STATUS_EMOJI[status.standup]);
+      if (status.standup) parts.push(statusEmoji(status.standup));
       parts.push(m.receiveNotifications ? "🔔" : "🔕");
       return parts.join(" · ");
     });

--- a/src/utils/memberStatusHelper.js
+++ b/src/utils/memberStatusHelper.js
@@ -1,0 +1,41 @@
+/**
+ * Pure resolver for a team member's display status.
+ * @param {Object} member
+ * @param {('ADMIN'|'MEMBER')} member.role
+ * @param {boolean} member.teamActive  TeamMember.isActive
+ * @param {boolean} member.orgActive   OrganizationMember.isActive
+ * @param {boolean} member.onLeave     leave overlaps today
+ * @param {boolean} member.workingToday today is a work day (and not a holiday)
+ * @param {boolean} member.responded   submitted a standup today
+ * @returns {{active: boolean, inactiveScope: ('team'|'org'|null), standup: ('leave'|'submitted'|'pending'|null)}}
+ */
+function deriveMemberStatus({
+  role,
+  teamActive,
+  orgActive,
+  onLeave,
+  workingToday,
+  responded,
+}) {
+  const active = teamActive && orgActive;
+  if (!active) {
+    return {
+      active: false,
+      inactiveScope: !teamActive ? "team" : "org",
+      standup: null,
+    };
+  }
+
+  let standup;
+  if (onLeave) {
+    standup = "leave";
+  } else if (role === "ADMIN" || !workingToday) {
+    standup = null;
+  } else {
+    standup = responded ? "submitted" : "pending";
+  }
+
+  return { active: true, inactiveScope: null, standup };
+}
+
+module.exports = { deriveMemberStatus };

--- a/test/services/teamServiceMemberStatus.test.js
+++ b/test/services/teamServiceMemberStatus.test.js
@@ -27,14 +27,28 @@ beforeEach(() => {
   prisma.organizationMember.findMany.mockResolvedValue([
     { userId: "u1", isActive: true },
     { userId: "u2", isActive: false },
+    { userId: "u3", isActive: true },
   ]);
-  prisma.standupResponse.findMany.mockResolvedValue([{ userId: "u1" }]);
-  prisma.leave.findMany.mockResolvedValue([{ userId: "u3" }]);
+  prisma.standupResponse.findMany.mockResolvedValue([
+    {
+      teamId: "t1",
+      userId: "u1",
+      standupDate: new Date("2026-06-24T12:00:00Z"),
+    },
+  ]);
+  prisma.leave.findMany.mockResolvedValue([
+    {
+      userId: "u3",
+      startDate: new Date("2026-06-01T00:00:00Z"),
+      endDate: new Date("2026-12-31T00:00:00Z"),
+    },
+  ]);
   prisma.teamMember.findMany.mockResolvedValue([
     {
       role: "MEMBER",
       isActive: true,
       receiveNotifications: true,
+      teamId: "t1",
       userId: "u1",
       user: {
         id: "u1",
@@ -47,6 +61,7 @@ beforeEach(() => {
       role: "MEMBER",
       isActive: true,
       receiveNotifications: false,
+      teamId: "t1",
       userId: "u2",
       user: { id: "u2", slackUserId: "U2", name: "Bob", workDays: null },
     },
@@ -54,6 +69,7 @@ beforeEach(() => {
       role: "ADMIN",
       isActive: true,
       receiveNotifications: true,
+      teamId: "t1",
       userId: "u3",
       user: { id: "u3", slackUserId: "U3", name: "Carol", workDays: null },
     },
@@ -81,5 +97,57 @@ describe("getTeamMembersWithStatus", () => {
   it("returns [] when the team has no members", async () => {
     prisma.teamMember.findMany.mockResolvedValue([]);
     expect(await teamService.getTeamMembersWithStatus("t1", WED)).toEqual([]);
+  });
+
+  it("treats a member with no org-membership row as org-inactive", async () => {
+    prisma.organizationMember.findMany.mockResolvedValue([]); // no rows at all
+    const out = await teamService.getTeamMembersWithStatus("t1", WED);
+    expect(out.every((m) => m.orgActive === false)).toBe(true);
+  });
+});
+
+describe("getMembersWithStatusByTeam", () => {
+  it("groups members by team id and returns an entry per team", async () => {
+    prisma.teamMember.findMany.mockResolvedValue([
+      {
+        role: "MEMBER",
+        isActive: true,
+        receiveNotifications: true,
+        teamId: "t1",
+        userId: "u1",
+        user: { id: "u1", slackUserId: "U1", name: "Alice", workDays: null },
+      },
+      {
+        role: "MEMBER",
+        isActive: true,
+        receiveNotifications: true,
+        teamId: "t2",
+        userId: "u2",
+        user: { id: "u2", slackUserId: "U2", name: "Bob", workDays: null },
+      },
+    ]);
+
+    const teams = [
+      { id: "t1", timezone: "America/New_York" },
+      { id: "t2", timezone: "America/New_York" },
+    ];
+    const byTeam = await teamService.getMembersWithStatusByTeam(
+      teams,
+      team.organization,
+      WED
+    );
+
+    expect(byTeam.get("t1").map((m) => m.user.slackUserId)).toEqual(["U1"]);
+    expect(byTeam.get("t2").map((m) => m.user.slackUserId)).toEqual(["U2"]);
+  });
+
+  it("returns an empty map entry for each team when there are no members", async () => {
+    prisma.teamMember.findMany.mockResolvedValue([]);
+    const byTeam = await teamService.getMembersWithStatusByTeam(
+      [{ id: "t1", timezone: "UTC" }],
+      team.organization,
+      WED
+    );
+    expect(byTeam.get("t1")).toEqual([]);
   });
 });

--- a/test/services/teamServiceMemberStatus.test.js
+++ b/test/services/teamServiceMemberStatus.test.js
@@ -1,0 +1,85 @@
+jest.mock("../../src/config/prisma", () => ({
+  team: { findUnique: jest.fn() },
+  teamMember: { findMany: jest.fn() },
+  organizationMember: { findMany: jest.fn() },
+  standupResponse: { findMany: jest.fn() },
+  leave: { findMany: jest.fn() },
+  holiday: { findMany: jest.fn() },
+}));
+
+const prisma = require("../../src/config/prisma");
+const teamService = require("../../src/services/teamService");
+
+const team = {
+  id: "t1",
+  organizationId: "o1",
+  timezone: "America/New_York",
+  organization: { id: "o1", settings: { defaultWorkDays: [1, 2, 3, 4, 5] } },
+};
+
+// A fixed work-day Wednesday (ISO day 3) for deterministic workingToday.
+const WED = new Date("2026-06-24T12:00:00Z");
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  prisma.team.findUnique.mockResolvedValue(team);
+  prisma.holiday.findMany.mockResolvedValue([]);
+  prisma.organizationMember.findMany.mockResolvedValue([
+    { userId: "u1", isActive: true },
+    { userId: "u2", isActive: false },
+  ]);
+  prisma.standupResponse.findMany.mockResolvedValue([{ userId: "u1" }]);
+  prisma.leave.findMany.mockResolvedValue([{ userId: "u3" }]);
+  prisma.teamMember.findMany.mockResolvedValue([
+    {
+      role: "MEMBER",
+      isActive: true,
+      receiveNotifications: true,
+      userId: "u1",
+      user: {
+        id: "u1",
+        slackUserId: "U1",
+        name: "Alice",
+        workDays: [1, 2, 3, 4, 5],
+      },
+    },
+    {
+      role: "MEMBER",
+      isActive: true,
+      receiveNotifications: false,
+      userId: "u2",
+      user: { id: "u2", slackUserId: "U2", name: "Bob", workDays: null },
+    },
+    {
+      role: "ADMIN",
+      isActive: true,
+      receiveNotifications: true,
+      userId: "u3",
+      user: { id: "u3", slackUserId: "U3", name: "Carol", workDays: null },
+    },
+  ]);
+});
+
+describe("getTeamMembersWithStatus", () => {
+  it("enriches each member with responded/onLeave/orgActive/workingToday", async () => {
+    const out = await teamService.getTeamMembersWithStatus("t1", WED);
+    const byId = Object.fromEntries(out.map((m) => [m.user.slackUserId, m]));
+
+    expect(byId.U1).toMatchObject({
+      role: "MEMBER",
+      teamActive: true,
+      orgActive: true,
+      receiveNotifications: true,
+      onLeave: false,
+      responded: true,
+      workingToday: true,
+    });
+    expect(byId.U2).toMatchObject({ orgActive: false, responded: false });
+    expect(byId.U3).toMatchObject({ role: "ADMIN", onLeave: true });
+  });
+
+  it("returns [] when the team has no members", async () => {
+    prisma.teamMember.findMany.mockResolvedValue([]);
+    expect(await teamService.getTeamMembersWithStatus("t1", WED)).toEqual([]);
+  });
+});

--- a/test/utils/memberStatusHelper.test.js
+++ b/test/utils/memberStatusHelper.test.js
@@ -1,0 +1,61 @@
+const { deriveMemberStatus } = require("../../src/utils/memberStatusHelper");
+
+const base = {
+  role: "MEMBER",
+  teamActive: true,
+  orgActive: true,
+  onLeave: false,
+  workingToday: true,
+  responded: false,
+};
+
+describe("deriveMemberStatus", () => {
+  it("flags team-inactive members and suppresses standup", () => {
+    expect(deriveMemberStatus({ ...base, teamActive: false })).toEqual({
+      active: false,
+      inactiveScope: "team",
+      standup: null,
+    });
+  });
+
+  it("flags org-inactive members (team active) as org scope", () => {
+    expect(deriveMemberStatus({ ...base, orgActive: false })).toEqual({
+      active: false,
+      inactiveScope: "org",
+      standup: null,
+    });
+  });
+
+  it("prefers team scope when inactive in both", () => {
+    expect(
+      deriveMemberStatus({ ...base, teamActive: false, orgActive: false })
+        .inactiveScope
+    ).toBe("team");
+  });
+
+  it("shows on-leave even for admins", () => {
+    expect(
+      deriveMemberStatus({ ...base, role: "ADMIN", onLeave: true }).standup
+    ).toBe("leave");
+  });
+
+  it("suppresses standup for active admins", () => {
+    expect(deriveMemberStatus({ ...base, role: "ADMIN" }).standup).toBeNull();
+  });
+
+  it("suppresses standup on a non-work-day", () => {
+    expect(
+      deriveMemberStatus({ ...base, workingToday: false }).standup
+    ).toBeNull();
+  });
+
+  it("reports submitted when responded on a work day", () => {
+    expect(deriveMemberStatus({ ...base, responded: true }).standup).toBe(
+      "submitted"
+    );
+  });
+
+  it("reports pending when not responded on a work day", () => {
+    expect(deriveMemberStatus(base).standup).toBe("pending");
+  });
+});

--- a/test/utils/teamMemberStatusBlocks.test.js
+++ b/test/utils/teamMemberStatusBlocks.test.js
@@ -164,6 +164,15 @@ describe("large-team guards", () => {
     expect(teamBlock.text.text).toContain("…and");
   });
 
+  it("Option A clamps a team section to 3000 chars even when the team name is huge", () => {
+    const hugeTeam = { ...team, name: "X".repeat(5000) };
+    const blocks = createTeamListWithMembersBlocks({
+      heading: "*📋 Your teams:*",
+      teams: [{ team: hugeTeam, members: [makeMember(1)] }],
+    });
+    expect(blocks[1].text.text.length).toBeLessThanOrEqual(3000);
+  });
+
   it("Option A caps the number of team blocks under the 50-block limit", () => {
     const teams = Array.from({ length: 60 }, (_, i) => ({
       team: { ...team, name: `Team ${i}` },

--- a/test/utils/teamMemberStatusBlocks.test.js
+++ b/test/utils/teamMemberStatusBlocks.test.js
@@ -1,0 +1,129 @@
+// test/utils/teamMemberStatusBlocks.test.js
+const {
+  createTeamMembersStatusBlocks,
+  createTeamListWithMembersBlocks,
+} = require("../../src/utils/blockHelper");
+
+const team = {
+  name: "Engineering",
+  standupTime: "09:30",
+  postingTime: "10:00",
+  timezone: "America/New_York",
+};
+
+const members = [
+  {
+    user: { slackUserId: "U1", name: "Alice" },
+    role: "ADMIN",
+    teamActive: true,
+    orgActive: true,
+    receiveNotifications: true,
+    onLeave: false,
+    workingToday: true,
+    responded: false,
+  },
+  {
+    user: { slackUserId: "U2", name: "Bob" },
+    role: "MEMBER",
+    teamActive: true,
+    orgActive: true,
+    receiveNotifications: false,
+    onLeave: false,
+    workingToday: true,
+    responded: false,
+  },
+  {
+    user: { slackUserId: "U3", name: "Carol" },
+    role: "MEMBER",
+    teamActive: true,
+    orgActive: true,
+    receiveNotifications: true,
+    onLeave: true,
+    workingToday: true,
+    responded: false,
+  },
+  {
+    user: { slackUserId: "U4", name: "Dave" },
+    role: "MEMBER",
+    teamActive: true,
+    orgActive: true,
+    receiveNotifications: true,
+    onLeave: false,
+    workingToday: true,
+    responded: true,
+  },
+  {
+    user: { slackUserId: "U5", name: "Eve" },
+    role: "MEMBER",
+    teamActive: false,
+    orgActive: true,
+    receiveNotifications: true,
+    onLeave: false,
+    workingToday: true,
+    responded: false,
+  },
+];
+
+function allText(blocks) {
+  return blocks
+    .map((b) => b.text?.text || (b.elements || []).map((e) => e.text).join(" "))
+    .join("\n");
+}
+
+describe("createTeamMembersStatusBlocks (Option C)", () => {
+  const blocks = createTeamMembersStatusBlocks(team, members);
+  const text = allText(blocks);
+
+  it("shows an active/inactive count header", () => {
+    expect(text).toContain("4 active");
+    expect(text).toContain("1 inactive");
+  });
+
+  it("suppresses standup for the admin but shows notifications + active", () => {
+    expect(text).toContain("👑 *Alice* (<@U1>) — Admin");
+    // Scoped to Alice's own block: the plan's `/Alice[\s\S]*Not submitted/`
+    // greedily spans into Bob's card (joined text), so it false-positives on
+    // correct output. Intent is "Alice's card has no 'Not submitted'".
+    const aliceBlock = blocks.find((b) => b.text?.text?.includes("Alice"));
+    expect(aliceBlock.text.text).not.toContain("Not submitted");
+    expect(text).toContain("🔔 Notifications on");
+  });
+
+  it("renders pending, on-leave, submitted, and inactive", () => {
+    expect(text).toContain("⏳ Not submitted");
+    expect(text).toContain("🔕 Notifications off");
+    expect(text).toContain("🌴 On leave today");
+    expect(text).toContain("✅ Submitted today");
+    expect(text).toContain("💤 *Eve* (<@U5>) — Member");
+    expect(text).toContain("⚪ Inactive in team");
+  });
+});
+
+describe("createTeamListWithMembersBlocks (Option A)", () => {
+  const blocks = createTeamListWithMembersBlocks({
+    heading: "*📋 Your teams:*",
+    teams: [{ team, members }],
+  });
+  const text = allText(blocks);
+
+  it("keeps the per-team meta line", () => {
+    expect(text).toContain("*👥 Engineering");
+    expect(text).toContain("🔔 Reminder: 9:30 AM");
+    expect(text).toContain("📊 Posting: 10:00 AM");
+    expect(text).toContain("🌍 America/New_York");
+  });
+
+  it("renders compact member lines with status emoji", () => {
+    expect(text).toContain("👑 <@U1> · 🔔");
+    expect(text).toContain("👤 <@U2> · ⏳ · 🔕");
+    expect(text).toContain("👤 <@U3> · 🌴 · 🔔");
+    expect(text).toContain("👤 <@U4> · ✅ · 🔔");
+    expect(text).toContain("💤 <@U5> · inactive");
+  });
+
+  it("ends with a legend context block", () => {
+    const last = blocks[blocks.length - 1];
+    expect(last.type).toBe("context");
+    expect(last.elements[0].text).toContain("✅ submitted");
+  });
+});

--- a/test/utils/teamMemberStatusBlocks.test.js
+++ b/test/utils/teamMemberStatusBlocks.test.js
@@ -127,3 +127,59 @@ describe("createTeamListWithMembersBlocks (Option A)", () => {
     expect(last.elements[0].text).toContain("✅ submitted");
   });
 });
+
+function makeMember(i) {
+  return {
+    user: { slackUserId: `U${i}`, name: `Member ${i}` },
+    role: "MEMBER",
+    teamActive: true,
+    orgActive: true,
+    receiveNotifications: true,
+    onLeave: false,
+    workingToday: true,
+    responded: false,
+  };
+}
+
+describe("large-team guards", () => {
+  it("Option C caps member cards under the 50-block limit", () => {
+    const many = Array.from({ length: 60 }, (_, i) => makeMember(i));
+    const blocks = createTeamMembersStatusBlocks(team, many);
+
+    expect(blocks.length).toBeLessThanOrEqual(50);
+    const last = blocks[blocks.length - 1];
+    expect(last.type).toBe("context");
+    expect(last.elements[0].text).toContain("13 more members not shown");
+  });
+
+  it("Option A keeps each team's section text within the 3000-char limit", () => {
+    const many = Array.from({ length: 300 }, (_, i) => makeMember(i));
+    const blocks = createTeamListWithMembersBlocks({
+      heading: "*📋 Your teams:*",
+      teams: [{ team, members: many }],
+    });
+
+    const teamBlock = blocks[1];
+    expect(teamBlock.text.text.length).toBeLessThanOrEqual(3000);
+    expect(teamBlock.text.text).toContain("…and");
+  });
+
+  it("Option A caps the number of team blocks under the 50-block limit", () => {
+    const teams = Array.from({ length: 60 }, (_, i) => ({
+      team: { ...team, name: `Team ${i}` },
+      members: [makeMember(i)],
+    }));
+    const blocks = createTeamListWithMembersBlocks({
+      heading: "*📋 Teams:*",
+      teams,
+    });
+
+    expect(blocks.length).toBeLessThanOrEqual(50);
+    const text = blocks
+      .map(
+        (b) => b.text?.text || (b.elements || []).map((e) => e.text).join(" ")
+      )
+      .join("\n");
+    expect(text).toContain("more teams not shown");
+  });
+});

--- a/web/src/data/changelog.json
+++ b/web/src/data/changelog.json
@@ -1,6 +1,21 @@
 {
   "versions": [
     {
+      "version": "1.16.0",
+      "date": "2026-06-23",
+      "isLatest": false,
+      "changes": [
+        {
+          "type": "added",
+          "title": "See who's done their standup at a glance",
+          "items": [
+            "/dd-team-members now shows each member's status — submitted, not yet, on leave, notifications, and role.",
+            "/dd-team-list lists members under each team with the same at-a-glance status."
+          ]
+        }
+      ]
+    },
+    {
       "version": "1.15.2",
       "date": "2026-06-21",
       "isLatest": true,


### PR DESCRIPTION
## Summary

Surfaces each team member's current status in two existing Slack commands:

- **`/dd-team-members`** — detailed two-line card per member (role, today's standup, on-leave, notifications, active/inactive).
- **`/dd-team-list`** — keeps the per-team meta line and nests a compact one-line-per-member status list under each team, with a legend.

"Status" = today's standup (submitted/not), on leave today, notifications on/off, role, and active/inactive (team **and** org). Standup status is suppressed for admins and on non-work-days/holidays, consistent with how reminders and posted summaries treat them.

## Changes

- **`deriveMemberStatus`** (`src/utils/memberStatusHelper.js`) — pure precedence resolver (inactive → on-leave → admin → non-work-day → submitted → pending), fully unit-tested.
- **`teamService.getTeamMembersWithStatus`** — assembles role, team/org-active, on-leave, working-today, and responded; reuses `getHolidayDateSet`/`isWorkingDayPure` for work-day gating.
- **`blockHelper`** — `createTeamMembersStatusBlocks` (Option C) and `createTeamListWithMembersBlocks` (Option A) + legend.
- Wired both command handlers (`team.js`); `/dd-team-list` fetches per-team status **sequentially** (no cross-team fan-out).
- **Large-team guards** — cap member cards / team blocks under Slack's 50-block limit and truncate per-team lines under the 3000-char section cap, each with a "+N more not shown" note.
- Docs: README, CHANGELOG.md, user-facing changelog.json.

## Notes for review

- **Timezone correctness:** work-day resolution uses the current instant (mirroring `standupService.getActiveMembers`), not team-local midnight — a midnight instant resolves to the wrong calendar day for off-UTC teams (`getDayOfWeekIso` is server-local, `toIsoDate` is UTC).
- **`changelog.json` version `1.16.0`** is a placeholder with `isLatest: false` (won't broadcast prematurely); reconcile during release.
- **Still needs live Slack verification** — emoji/mention/legend rendering isn't covered by unit tests.

## Test plan

- `npx jest` — 259 passing (added: `deriveMemberStatus`, `getTeamMembersWithStatus`, block helpers incl. large-team guards).
- `npm run lint` — clean.
- Manual: run `/dd-team-members` and `/dd-team-list` in Slack as a regular member and as an org owner/admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Team member information in `/dd-team-members` and `/dd-team-list` commands now displays additional status indicators: standup submission status, leave status, notification preferences, role, and active/inactive state. Standup status is hidden for admins and on non-working days or holidays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->