### PR TITLE
fix: escape Slack control characters in MCP standup submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- MCP standup submissions (`submit_standup` / `update_standup`) now escape Slack mrkdwn control characters (`&`, `<`, `>`) in `yesterdayTasks`, `todayTasks`, and `blockers` before storing them, via `escapeSlackText`. Previously the LLM-supplied text was stored verbatim, so a submission containing angle brackets — e.g. a PR title like "password with < or > characters" — was parsed by Slack as broken link/mention syntax and corrupted the entire posted standup message. This brings the MCP path in line with the modal path, which already escapes raw text during rich-text extraction (`extractRichTextValue`). (`src/mcp/tools.js`)
+- MCP standup submissions (`submit_standup` / `update_standup`) now escape Slack mrkdwn control characters (`&`, `<`, `>`) in `yesterdayTasks`, `todayTasks`, and `blockers` before storing them, via a shared `escapeStandupFields` helper (built on `escapeSlackText`). Previously the LLM-supplied text was stored verbatim, so a submission containing angle brackets — e.g. a PR title like "password with < or > characters" — was parsed by Slack as broken link/mention syntax and corrupted the entire posted standup message. This brings the MCP path in line with the modal path, which already escapes raw text during rich-text extraction (`extractRichTextValue`). `preview_standup` escapes the same way so its `fields`/`preview` match what gets stored (and the already-escaped `existing` value). (`src/mcp/tools.js`)
 
 ## [1.16.0] - 2026-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- MCP standup submissions (`submit_standup` / `update_standup`) now escape Slack mrkdwn control characters (`&`, `<`, `>`) in `yesterdayTasks`, `todayTasks`, and `blockers` before storing them, via `escapeSlackText`. Previously the LLM-supplied text was stored verbatim, so a submission containing angle brackets — e.g. a PR title like "password with < or > characters" — was parsed by Slack as broken link/mention syntax and corrupted the entire posted standup message. This brings the MCP path in line with the modal path, which already escapes raw text during rich-text extraction (`extractRichTextValue`). (`src/mcp/tools.js`)
+
 ## [1.16.0] - 2026-06-23
 
 ### Added

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -26,13 +26,24 @@ function assertValidDate(date) {
   }
 }
 
-// MCP standup fields are plain text drafted by an LLM and stored verbatim, then
-// rendered straight into Slack mrkdwn when posted. Slack treats &, < and > as
-// control characters (entities / links / mentions), so unescaped angle brackets
-// in a submission — e.g. a PR title like "password with < or > characters" —
-// corrupt the whole posted message. Escape them here so MCP submissions match
-// the modal path, which already escapes raw text during rich-text extraction
-// (see messageHelper.escapeSlackText / extractRichTextValue).
+/**
+ * Escape Slack mrkdwn control characters in the three standup text fields.
+ *
+ * MCP standup fields are plain text drafted by an LLM and stored verbatim, then
+ * rendered straight into Slack mrkdwn when posted. Slack treats &, < and > as
+ * control characters (entities / links / mentions), so unescaped angle brackets
+ * in a submission — e.g. a PR title like "password with < or > characters" —
+ * corrupt the whole posted message. Escaping here keeps MCP submissions in line
+ * with the modal path, which already escapes raw text during rich-text
+ * extraction (see messageHelper.escapeSlackText / extractRichTextValue).
+ *
+ * @param {object} fields - Raw standup fields from the MCP tool input.
+ * @param {string} [fields.yesterdayTasks] - Last working day's tasks.
+ * @param {string} [fields.todayTasks] - Today's planned tasks.
+ * @param {string} [fields.blockers] - Current blockers.
+ * @returns {{yesterdayTasks: string, todayTasks: string, blockers: string}} The
+ *   same fields with &, < and > escaped, safe to render as Slack mrkdwn.
+ */
 function escapeStandupFields({
   yesterdayTasks = "",
   todayTasks = "",
@@ -206,7 +217,14 @@ function buildToolHandlers(user, slackClient) {
           }
         : null;
 
-      const fields = { yesterdayTasks, todayTasks, blockers };
+      // Escape exactly as submit_standup/update_standup do, so the preview
+      // (and the returned fields) match what will actually be stored — the
+      // stored `existing` value above is likewise already escaped.
+      const fields = escapeStandupFields({
+        yesterdayTasks,
+        todayTasks,
+        blockers,
+      });
       return {
         team: resolved.name,
         date: dateStr,

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -10,6 +10,7 @@ const { resolveMember } = require("./memberResolver");
 const standupService = require("../services/standupService");
 const teamService = require("../services/teamService");
 const schedulerService = require("../services/schedulerService");
+const { escapeSlackText } = require("../utils/messageHelper");
 
 // Extend the plugins this module relies on directly — do not depend on another
 // module's import side-effects (which won't run when that module is mocked).
@@ -23,6 +24,25 @@ function assertValidDate(date) {
   if (!DATE_RE.test(date) || !dayjs(date, "YYYY-MM-DD", true).isValid()) {
     throw new Error(`Invalid date "${date}". Use YYYY-MM-DD format.`);
   }
+}
+
+// MCP standup fields are plain text drafted by an LLM and stored verbatim, then
+// rendered straight into Slack mrkdwn when posted. Slack treats &, < and > as
+// control characters (entities / links / mentions), so unescaped angle brackets
+// in a submission — e.g. a PR title like "password with < or > characters" —
+// corrupt the whole posted message. Escape them here so MCP submissions match
+// the modal path, which already escapes raw text during rich-text extraction
+// (see messageHelper.escapeSlackText / extractRichTextValue).
+function escapeStandupFields({
+  yesterdayTasks = "",
+  todayTasks = "",
+  blockers = "",
+}) {
+  return {
+    yesterdayTasks: escapeSlackText(yesterdayTasks),
+    todayTasks: escapeSlackText(todayTasks),
+    blockers: escapeSlackText(blockers),
+  };
 }
 
 function formatStandupPreview(teamName, date, fields) {
@@ -114,7 +134,7 @@ function buildToolHandlers(user, slackClient) {
         team: full,
         slackUserId: user.slackUserId,
         name: user.name || user.slackUserId,
-        fields: { yesterdayTasks, todayTasks, blockers },
+        fields: escapeStandupFields({ yesterdayTasks, todayTasks, blockers }),
         standupDate: dayjs().tz(full.timezone).toDate(),
         isUpdate: false,
         slackClient,
@@ -145,7 +165,7 @@ function buildToolHandlers(user, slackClient) {
         team: full,
         slackUserId: user.slackUserId,
         name: user.name || user.slackUserId,
-        fields: { yesterdayTasks, todayTasks, blockers },
+        fields: escapeStandupFields({ yesterdayTasks, todayTasks, blockers }),
         standupDate: dayjs(date, "YYYY-MM-DD").toDate(),
         isUpdate: true,
         slackClient,

--- a/test/mcp/tools.preview.test.js
+++ b/test/mcp/tools.preview.test.js
@@ -89,6 +89,25 @@ describe("preview_standup handler", () => {
     });
   });
 
+  it("escapes Slack control characters (&, <, >) in the preview and returned fields", async () => {
+    standupService.getUserResponse.mockResolvedValue(null);
+    const result = await tools.preview_standup({
+      team: "Eng",
+      date: "2026-06-17",
+      yesterdayTasks: "password with < or > characters",
+      todayTasks: "ship <feature> & fix",
+      blockers: "<script>",
+    });
+    // Fields and preview must match what submit_standup/update_standup store.
+    expect(result.fields).toEqual({
+      yesterdayTasks: "password with &lt; or &gt; characters",
+      todayTasks: "ship &lt;feature&gt; &amp; fix",
+      blockers: "&lt;script&gt;",
+    });
+    expect(result.preview).toContain("ship &lt;feature&gt; &amp; fix");
+    expect(result.preview).not.toContain("ship <feature>");
+  });
+
   it("rejects an invalid date", async () => {
     await expect(
       tools.preview_standup({

--- a/test/mcp/tools.test.js
+++ b/test/mcp/tools.test.js
@@ -102,6 +102,60 @@ describe("MCP Phase 1 tool handlers", () => {
     );
   });
 
+  it("submit_standup escapes Slack control characters (&, <, >) in all fields", async () => {
+    resolveTeam.mockResolvedValue({ team: { id: "t1", name: "Eng" } });
+    teamService.getTeamById.mockResolvedValue({
+      id: "t1",
+      name: "Eng",
+      timezone: "Asia/Dhaka",
+    });
+    standupService.submitStandup.mockResolvedValue({ isLate: false });
+
+    await tools.submit_standup({
+      team: "Eng",
+      yesterdayTasks: "password with < or > characters",
+      todayTasks: "Tom & Jerry",
+      blockers: "<script>",
+    });
+
+    expect(standupService.submitStandup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fields: {
+          yesterdayTasks: "password with &lt; or &gt; characters",
+          todayTasks: "Tom &amp; Jerry",
+          blockers: "&lt;script&gt;",
+        },
+      })
+    );
+  });
+
+  it("update_standup escapes Slack control characters (&, <, >) in all fields", async () => {
+    resolveTeam.mockResolvedValue({ team: { id: "t1", name: "Eng" } });
+    teamService.getTeamById.mockResolvedValue({
+      id: "t1",
+      name: "Eng",
+      timezone: "Asia/Dhaka",
+    });
+    standupService.submitStandup.mockResolvedValue({ isLate: false });
+
+    await tools.update_standup({
+      team: "Eng",
+      date: "2026-06-23",
+      todayTasks: "ship <feature> & fix",
+    });
+
+    expect(standupService.submitStandup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isUpdate: true,
+        fields: {
+          yesterdayTasks: "",
+          todayTasks: "ship &lt;feature&gt; &amp; fix",
+          blockers: "",
+        },
+      })
+    );
+  });
+
   it("submit_standup throws the resolver error for an unknown team", async () => {
     resolveTeam.mockResolvedValue({
       error: 'Team "X" not found. Available teams: Eng',

--- a/web/src/data/changelog.json
+++ b/web/src/data/changelog.json
@@ -1,9 +1,23 @@
 {
   "versions": [
     {
-      "version": "1.16.0",
+      "version": "1.16.1",
       "date": "2026-06-23",
       "isLatest": true,
+      "changes": [
+        {
+          "type": "fixed",
+          "title": "Standups with < or > characters post correctly",
+          "items": [
+            "Standup text containing characters like < or > (for example a pull request title) no longer breaks the posted standup summary when your standup is submitted through a connected AI agent."
+          ]
+        }
+      ]
+    },
+    {
+      "version": "1.16.0",
+      "date": "2026-06-23",
+      "isLatest": false,
       "changes": [
         {
           "type": "added",


### PR DESCRIPTION
## Problem

A standup posted to a channel was corrupted when its text contained `<` or `>` characters — for example a PR title like **"Fix: SFTP password with < or > characters HTML-encoded in backup scripts"**. Slack mrkdwn treats `&`, `<`, and `>` as control characters (entities / links / mentions), so the unescaped angle brackets were parsed as broken link/mention syntax, mangling the whole posted message.

## Root cause

The MCP standup write tools (`submit_standup` / `update_standup`) stored the LLM-supplied `yesterdayTasks`, `todayTasks`, and `blockers` **verbatim**, then rendered them straight into Slack mrkdwn when the summary was posted (`postTeamStandup` / `postIndividualResponse` / late-thread replies).

The modal submission path (`handleStandupSubmission` / `handleStandupUpdateSubmission`) was already safe — it escapes raw text during rich-text extraction (`messageHelper.extractRichTextValue` → `escapeSlackText`). The MCP path simply never had the equivalent step.

## Fix

Escape the three fields with `messageHelper.escapeSlackText` (`&`→`&amp;`, `<`→`&lt;`, `>`→`&gt;`) at the MCP submission boundary, before handing them to `submitStandup`. This brings the MCP path in line with the modal path so **all submission types** produce Slack-safe stored text.

Escaping is applied at write time (per path) rather than render time, because the modal path already stores escaped mrkdwn (with structured `<url|text>` links and `*bold*` intact) — re-escaping at render time would double-escape and break those. `preview_standup` is intentionally left unescaped since it returns human-readable text to the agent and is never posted to a channel.

## Changes

- `src/mcp/tools.js` — new `escapeStandupFields()` helper; applied in `submit_standup` and `update_standup`.
- `test/mcp/tools.test.js` — tests asserting `&`, `<`, `>` are escaped across all three fields for both tools.
- `CHANGELOG.md` / `web/src/data/changelog.json` — fix documented.

## Testing

- `npm test` — 265 tests pass (incl. 2 new).
- `npm run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181YtcRc7JDgncf8iC6qMNU

---
_Generated by [Claude Code](https://claude.ai/code/session_0181YtcRc7JDgncf8iC6qMNU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Fixed standup submission messages containing special characters (`<`, `>`, `&`) displaying incorrectly on Slack. These characters are now properly escaped to prevent Slack mis-parsing, ensuring standup messages post as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->